### PR TITLE
Show Sankey module from home tab button

### DIFF
--- a/app.R
+++ b/app.R
@@ -51,16 +51,18 @@ ui <- navbarPage(
         )
       )
     ),
+    conditionalPanel(
+      condition = "input.open_sankey >= 1",
+      hr(),
+      h3("Sankey Plot Builder"),
+      sankey_app_ui("sankey")
+    ),
     hr(),
     tags$footer(
       align = "center",
       style = "margin-top: 40px; color: #777;",
       "© 2025 Your Name — Built with R Shiny"
     )
-  ),
-  tabPanel(
-    title = "Sankey Plot Builder",
-    sankey_app_ui("sankey")
   )
 )
 
@@ -68,7 +70,7 @@ server <- function(input, output, session) {
   sankey_app_server("sankey")
 
   observeEvent(input$open_sankey, {
-    updateNavbarPage(session, inputId = "main_nav", selected = "Sankey Plot Builder")
+    updateNavbarPage(session, inputId = "main_nav", selected = "Home")
   })
 }
 


### PR DESCRIPTION
## Summary
- reveal the Sankey Plot Builder module directly within the Home tab when the call-to-action button is clicked
- remove the redundant navigation tab so users rely on the Home page entry point

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ecce0a84b48324b8b42db514b5c572