### PR TITLE
Refine homepage with updated professional profile

### DIFF
--- a/app.R
+++ b/app.R
@@ -9,27 +9,150 @@ ui <- navbarPage(
   theme = bs_theme(bootswatch = "flatly"),
   tabPanel(
     title = "Home",
-    fluidRow(
-      column(
-        3,
-        tags$img(
-          src = "my_photo.jpeg",
-          width = "100%",
-          style = "border-radius: 50%; box-shadow: 0 0 8px #aaa;"
+    fluidPage(
+      tags$section(
+        class = "py-4",
+        style = "background: linear-gradient(135deg, #f8f9fa 0%, #e9f5ff 100%); border-radius: 16px; padding: 32px;",
+        fluidRow(
+          column(
+            3,
+            tags$img(
+              src = "my_photo.jpeg",
+              width = "100%",
+              style = "border-radius: 50%; box-shadow: 0 10px 24px rgba(0,0,0,0.12);"
+            )
+          ),
+          column(
+            9,
+            h1("Dr. Nicola Palmieri"),
+            h4(class = "text-muted", "Bioinformatician · Genomics Researcher · Data Scientist"),
+            p(
+              "I am a Vienna-based researcher exploring genome evolution, microbial pathogenicity, and the genomics of host–pathogen interactions.",
+              "My work bridges bioinformatics, molecular biology, and neuroinformatics to uncover actionable insights from complex biological data."
+            ),
+            fluidRow(
+              column(
+                4,
+                tags$ul(
+                  class = "list-unstyled",
+                  tags$li(tags$strong("Location:"), " Vienna, Austria"),
+                  tags$li(tags$strong("Phone:"), " +43 676 4342779"),
+                  tags$li(tags$strong("Email:"), " ", tags$a(href = "mailto:nicola.palmieri@vetmeduni.ac.at", "nicola.palmieri@vetmeduni.ac.at"))
+                )
+              ),
+              column(
+                4,
+                tags$ul(
+                  class = "list-unstyled",
+                  tags$li(tags$strong("ORCID:"), " ", tags$a(href = "https://orcid.org/0000-0002-6164-1843/", "0000-0002-6164-1843")),
+                  tags$li(tags$strong("GitHub:"), " ", tags$a(href = "https://github.com/nicola-palmieri", "github.com/nicola-palmieri")),
+                  tags$li(tags$strong("LinkedIn:"), " ", tags$a(href = "https://www.linkedin.com/in/nicolapalmieri", "linkedin.com/in/nicolapalmieri"))
+                )
+              ),
+              column(
+                4,
+                tags$ul(
+                  class = "list-unstyled",
+                  tags$li(tags$strong("Languages:")),
+                  tags$li("Italian · English · German · Spanish · French")
+                )
+              )
+            )
+          )
         )
       ),
-      column(
-        9,
-        h3("About Me"),
-        p(
-          "I am a researcher working on bioinformatics, microbial genomics and brain organoids.",
-          "I build bioinformatics and visualization tools to make data exploration easier for colleagues."
-        ),
-        tags$ul(
-          tags$li("🔬 Fields: Bioinformatics, Genomics, Neural Data Analysis"),
-          tags$li("💡 Interests: Evolution, Organoids, R/Python pipelines"),
-          tags$li("📧 Contact: ", tags$a(href = "mailto:palmierinico@gmail.com", "palmierinico@gmail.com")),
-          tags$li("🌍 GitHub: ", tags$a(href = "https://github.com/nicola-palmieri", "github.com/nicola-palmieri"))
+      tags$section(
+        class = "mt-4",
+        fluidRow(
+          column(
+            4,
+            h3("Research Focus"),
+            tags$ul(
+              tags$li("Genomics and phylogenomics of pathogenic microorganisms"),
+              tags$li("Antibiotic resistance and virulence evolution"),
+              tags$li("Host–pathogen interactions across species"),
+              tags$li("Neuroinformatics and neural signal analysis")
+            )
+          ),
+          column(
+            4,
+            h3("Current Roles"),
+            tags$ul(
+              tags$li(tags$strong("Data Analyst"), ", a:head Bio, Vienna Biocenter (2021 – Present)"),
+              tags$li(tags$strong("Bioinformatician"), ", University Clinic for Poultry and Fish Medicine, Vetmeduni Vienna (2017 – Present)"),
+              tags$li(tags$strong("Postdoctoral Researcher"), ", Institute of Parasitology, Vetmeduni Vienna (2014 – 2018)")
+            )
+          ),
+          column(
+            4,
+            h3("Core Expertise"),
+            tags$ul(
+              tags$li("Genome sequencing, annotation, and comparative genomics"),
+              tags$li("RNA-Seq, Nanopore, and NGS data analysis"),
+              tags$li("Neuroinformatics pipelines for calcium imaging and MEA data"),
+              tags$li("Statistical modeling, machine learning, and data visualization")
+            )
+          )
+        )
+      ),
+      tags$section(
+        class = "mt-4",
+        h3("Selected Publications"),
+        tags$div(
+          class = "publication-card",
+          tags$ul(
+            class = "list-unstyled",
+            tags$li(
+              tags$strong("2023 · " ),
+              "The Genetic Network Underlying the Evolution of Pathogenicity in Avian Escherichia coli, Frontiers in Veterinary Science.",
+              " ", tags$a(href = "https://www.frontiersin.org/articles/10.3389/fvets.2023.1195585", "Read")
+            ),
+            tags$li(
+              tags$strong("2023 · " ),
+              "Gene Expression of Peripheral Blood Mononuclear Cells and CD8+ T Cells from Gilts after PRRSV Infection, Frontiers in Immunology.",
+              " ", tags$a(href = "https://www.frontiersin.org/articles/10.3389/fimmu.2023.1159970", "Read")
+            ),
+            tags$li(
+              tags$strong("2022 · " ),
+              "A Novel Chaphamaparvovirus Is the Etiological Agent of Hepatitis Outbreaks in Pheasants, Transboundary and Emerging Diseases.",
+              " ", tags$a(href = "https://doi.org/10.1111/tbed.14545", "Read")
+            ),
+            tags$li(
+              tags$strong("2021 · " ),
+              "Complete Genomes of the Eukaryotic Poultry Parasite Histomonas meleagridis: Linking Sequence Analysis with Virulence/Attenuation, BMC Genomics.",
+              " ", tags$a(href = "https://doi.org/10.1186/s12864-021-08059-2", "Read")
+            )
+          )
+        )
+      ),
+      tags$section(
+        class = "mt-4",
+        h3("Teaching & Software"),
+        fluidRow(
+          column(
+            6,
+            tags$div(
+              class = "card shadow-sm",
+              tags$div(
+                class = "card-body",
+                h4("Teaching"),
+                p("Doctoral Course Instructor in R and Python Programming, University of Veterinary Medicine Vienna (2009 – 2012)."),
+                p("Designed and delivered programming curricula for doctoral researchers with a focus on reproducible analytical workflows.")
+              )
+            )
+          ),
+          column(
+            6,
+            tags$div(
+              class = "card shadow-sm",
+              tags$div(
+                class = "card-body",
+                h4("Software Development"),
+                p("Proprietary R packages and Shiny applications developer at a:head Bio."),
+                p("Builds interactive analytics tools, dashboards, and pipelines that accelerate decision-making for translational research teams.")
+              )
+            )
+          )
         )
       )
     ),
@@ -37,7 +160,7 @@ ui <- navbarPage(
     tags$footer(
       align = "center",
       style = "margin-top: 40px; color: #777;",
-      "© 2025 Your Name — Built with R Shiny"
+      "© 2025 Dr. Nicola Palmieri — Built with R Shiny"
     )
   ),
   navbarMenu(


### PR DESCRIPTION
## Summary
- redesign the homepage hero section with an updated biography, contact information, and language profile
- add sections highlighting research focus, current roles, core expertise, and selected publications drawn from the latest CV
- feature teaching and software development contributions in card-style callouts with refreshed styling and footer attribution

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68ee12b8cee08324bef8743987aacec1