### PR TITLE
Fix analysis module column selection

### DIFF
--- a/animal_trial_analyzer_module.R
+++ b/animal_trial_analyzer_module.R
@@ -27,17 +27,14 @@ animal_trial_app_server <- function(id) {
     output$upload_section <- renderUI({
       upload_ui(ns("upload"))
     })
-    
+
     # --- 2️⃣ Filter (requires uploaded data)
     output$filter_section <- renderUI({
       req(uploaded())
       filter_ui(ns("filter"))
     })
-    filtered <- reactive({
-      req(uploaded())
-      filter_server("filter", uploaded)
-    })
-    
+    filtered <- filter_server("filter", uploaded)
+
     # --- 3️⃣ Analysis (requires uploaded data, not model yet)
     output$analysis_section <- renderUI({
       req(uploaded())


### PR DESCRIPTION
## Summary
- call the filter module directly so the analysis module receives the filtered data rather than a nested reactive
- ensure the ANOVA dropdowns populate with the available column names

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68eec19515a48324887a1fe4a89f35d6