### PR TITLE
Ensure analysis module exposes fitted model for visualization

### DIFF
--- a/R/animal_trial_analyzer/module_analysis.R
+++ b/R/animal_trial_analyzer/module_analysis.R
@@ -40,15 +40,23 @@ analysis_server <- function(id, filtered_data) {
     })
     
     # Dynamically run submodule
-    model_fit <- reactive({
-      req(input$analysis_type)
+    model_fit <- reactiveVal(NULL)
+
+    observeEvent(input$analysis_type, {
       if (input$analysis_type == "One-way ANOVA") {
-        one_way_anova_server("anova", df)
+        model_fit(one_way_anova_server("anova", df))
       } else {
-        NULL
+        model_fit(NULL)
       }
+    }, ignoreNULL = FALSE)
+
+    # Expose a reactive that yields the fitted model object once available
+    reactive({
+      model_reactive <- model_fit()
+      req(model_reactive)
+      model <- model_reactive()
+      req(model)
+      model
     })
-    
-    return(model_fit)
   })
 }


### PR DESCRIPTION
## Summary
- refactor the analysis module so it stores the ANOVA server result in a reactiveVal
- expose a reactive that returns the fitted model object once the analysis has been run
- unblock the visualization module by ensuring it receives the actual model instead of a nested reactive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68eec4644c1c8324ae2ef730a113e3f9