### PR TITLE
Guard analysis observer when type not yet set

### DIFF
--- a/R/animal_trial_analyzer/module_analysis.R
+++ b/R/animal_trial_analyzer/module_analysis.R
@@ -40,15 +40,25 @@ analysis_server <- function(id, filtered_data) {
     })
     
     # Dynamically run submodule
-    model_fit <- reactive({
+    model_fit <- reactiveVal(NULL)
+
+    observeEvent(input$analysis_type, {
       req(input$analysis_type)
+
       if (input$analysis_type == "One-way ANOVA") {
-        one_way_anova_server("anova", df)
+        model_fit(one_way_anova_server("anova", df))
       } else {
-        NULL
+        model_fit(NULL)
       }
+    }, ignoreNULL = FALSE)
+
+    # Expose a reactive that yields the fitted model object once available
+    reactive({
+      model_reactive <- model_fit()
+      req(model_reactive)
+      model <- model_reactive()
+      req(model)
+      model
     })
-    
-    return(model_fit)
   })
 }


### PR DESCRIPTION
## Summary
- ensure the analysis observer waits for a selected analysis type before running submodules
- prevent NULL analysis types from triggering errors during module initialization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68eec4644c1c8324ae2ef730a113e3f9