### PR TITLE
Add guard for analysis type initialization

### DIFF
--- a/R/animal_trial_analyzer/module_analysis.R
+++ b/R/animal_trial_analyzer/module_analysis.R
@@ -43,6 +43,7 @@ analysis_server <- function(id, filtered_data) {
     model_fit <- reactiveVal(NULL)
 
     observeEvent(input$analysis_type, {
+      req(input$analysis_type)
       if (input$analysis_type == "One-way ANOVA") {
         model_fit(one_way_anova_server("anova", df))
       } else {


### PR DESCRIPTION
## Summary
- ensure the analysis type observer waits for a valid selection before comparing it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efef55499c832ba9fb6df60e9fbe30