### PR TITLE
Fix upload module to reload on file replacement

### DIFF
--- a/R/animal_trial_analyzer/module_upload.R
+++ b/R/animal_trial_analyzer/module_upload.R
@@ -78,9 +78,9 @@ upload_server <- function(id) {
     }, ignoreInit = TRUE)
     
     # ---- STEP 2: load selected sheet ----
-    observeEvent(input$sheet, {
+    observeEvent(list(input$sheet, input$file$datapath), {
       req(input$file, input$sheet)
-      
+
       tmp <- tryCatch(
         read_excel(input$file$datapath, sheet = input$sheet),
         error = function(e) e
@@ -104,7 +104,7 @@ upload_server <- function(id) {
         tmp,
         options = list(scrollX = TRUE, pageLength = 5)
       )
-    }, ignoreInit = TRUE)
+    }, ignoreInit = TRUE, ignoreNULL = TRUE)
     
     return(df)
   })


### PR DESCRIPTION
## Summary
- trigger the sheet loading observer when either the selected sheet or the uploaded file path changes
- ensure replacing an uploaded workbook refreshes the preview and validation output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eff6d33ba8832bbd41274d40fa2c2d