### PR TITLE
Add multi-response support to ANOVA modules and visualization

### DIFF
--- a/R/animal_trial_analyzer/module_analysis_one-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_one-way_anova.R
@@ -13,8 +13,8 @@ one_way_anova_ui <- function(id) {
     br(),
     actionButton(ns("run"), "Run ANOVA"),
     br(), br(),
-    verbatimTextOutput(ns("summary")),
-    DTOutput(ns("fixed_effects"))
+    uiOutput(ns("summary_ui")),
+    uiOutput(ns("fixed_effects_ui"))
   )
 }
 
@@ -34,13 +34,27 @@ one_way_anova_server <- function(id, filtered_data) {
       num_cols <- names(data)[sapply(data, is.numeric)]
       cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
       
-      tagList(
+      response_input <- if (isTRUE(input$multi_resp)) {
+        selectizeInput(
+          ns("response"),
+          "Response variables (numeric):",
+          choices = num_cols,
+          selected = if (length(num_cols) > 0) num_cols[1] else NULL,
+          multiple = TRUE,
+          options = list(maxItems = 10)
+        )
+      } else {
         selectInput(
           ns("response"),
           "Response variable (numeric):",
           choices = num_cols,
           selected = if (length(num_cols) > 0) num_cols[1] else NULL
-        ),
+        )
+      }
+
+      tagList(
+        checkboxInput(ns("multi_resp"), "Enable multiple response variables", value = FALSE),
+        response_input,
         selectInput(
           ns("group"),
           "Grouping variable (factor):",
@@ -63,30 +77,117 @@ one_way_anova_server <- function(id, filtered_data) {
       )
     })
     
-    # Fit model
-    model <- eventReactive(input$run, {
-      req(df(), input$response, input$group)
+    # Fit model(s)
+    models <- eventReactive(input$run, {
+      req(df(), input$response, input$group, input$order)
+      responses <- input$response
+      if (!isTRUE(input$multi_resp)) {
+        responses <- responses[1]
+      }
+      responses <- unique(responses)
+      req(length(responses) > 0)
+
+      if (length(responses) > 10) {
+        validate(need(FALSE, "Please select at most 10 response variables."))
+      }
+
       data <- df()
       data[[input$group]] <- factor(data[[input$group]], levels = input$order)
-      model_formula <- as.formula(paste(input$response, "~", input$group))
-      lm(model_formula, data = data)
-    })
-    
-    # Outputs
-    output$summary <- renderPrint({
-      req(model())
-      summary(model())
-    })
-    
-    output$fixed_effects <- renderDT({
-      req(model())
-      datatable(
-        broom::tidy(model()),
-        options = list(scrollX = TRUE, pageLength = 5),
-        rownames = FALSE
+
+      model_list <- list()
+      for (resp in responses) {
+        model_formula <- as.formula(paste(resp, "~", input$group))
+        model_list[[resp]] <- lm(model_formula, data = data)
+      }
+
+      list(
+        models = model_list,
+        responses = responses,
+        factors = list(factor1 = input$group, factor2 = NULL),
+        orders = list(order1 = input$order, order2 = NULL)
       )
     })
-    
-    return(model)
+
+    # Summary outputs
+    output$summary_ui <- renderUI({
+      model_info <- models()
+      if (is.null(model_info)) {
+        return(NULL)
+      }
+
+      responses <- model_info$responses
+
+      if (length(responses) == 1) {
+        verbatimTextOutput(ns("summary_single"))
+      } else {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(responses[i], verbatimTextOutput(ns(paste0("summary_", i))))
+        })
+        do.call(tabsetPanel, c(list(id = ns("summary_tabs")), tabs))
+      }
+    })
+
+    # Fixed effects outputs
+    output$fixed_effects_ui <- renderUI({
+      model_info <- models()
+      if (is.null(model_info)) {
+        return(NULL)
+      }
+
+      responses <- model_info$responses
+
+      if (length(responses) == 1) {
+        DTOutput(ns("fixed_effects_single"))
+      } else {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(responses[i], DTOutput(ns(paste0("fixed_effects_", i))))
+        })
+        do.call(tabsetPanel, c(list(id = ns("fixed_effects_tabs")), tabs))
+      }
+    })
+
+    observeEvent(models(), {
+      model_info <- models()
+      if (is.null(model_info)) {
+        return()
+      }
+
+      responses <- model_info$responses
+      model_list <- model_info$models
+
+      if (length(responses) == 1) {
+        resp <- responses[1]
+        output$summary_single <- renderPrint({
+          summary(model_list[[resp]])
+        })
+        output$fixed_effects_single <- renderDT({
+          datatable(
+            broom::tidy(model_list[[resp]]),
+            options = list(scrollX = TRUE, pageLength = 5),
+            rownames = FALSE
+          )
+        })
+      } else {
+        for (i in seq_along(responses)) {
+          resp <- responses[i]
+          local({
+            idx <- i
+            response_name <- resp
+            output[[paste0("summary_", idx)]] <- renderPrint({
+              summary(model_list[[response_name]])
+            })
+            output[[paste0("fixed_effects_", idx)]] <- renderDT({
+              datatable(
+                broom::tidy(model_list[[response_name]]),
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+          })
+        }
+      }
+    })
+
+    return(models)
   })
 }

--- a/R/animal_trial_analyzer/module_analysis_two-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_two-way_anova.R
@@ -12,8 +12,8 @@ two_way_anova_ui <- function(id) {
     br(),
     actionButton(ns("run"), "Run Two-way ANOVA"),
     br(), br(),
-    verbatimTextOutput(ns("summary")),
-    DTOutput(ns("fixed_effects"))
+    uiOutput(ns("summary_ui")),
+    uiOutput(ns("fixed_effects_ui"))
   )
 }
 
@@ -35,13 +35,27 @@ two_way_anova_server <- function(id, filtered_data) {
       num_cols <- names(data)[sapply(data, is.numeric)]
       cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
       
-      tagList(
+      response_input <- if (isTRUE(input$multi_resp)) {
+        selectizeInput(
+          ns("response"),
+          "Response variables (numeric):",
+          choices = num_cols,
+          selected = if (length(num_cols) > 0) num_cols[1] else NULL,
+          multiple = TRUE,
+          options = list(maxItems = 10)
+        )
+      } else {
         selectInput(
           ns("response"),
           "Response variable (numeric):",
           choices = num_cols,
           selected = if (length(num_cols) > 0) num_cols[1] else NULL
-        ),
+        )
+      }
+
+      tagList(
+        checkboxInput(ns("multi_resp"), "Enable multiple response variables", value = FALSE),
+        response_input,
         selectInput(
           ns("factor1"),
           "First factor (x-axis):",
@@ -87,33 +101,115 @@ two_way_anova_server <- function(id, filtered_data) {
     # ----------------------------------------------
     # Fit two-way ANOVA model (fixed effects output)
     # ----------------------------------------------
-    model <- eventReactive(input$run, {
-      req(df(), input$response, input$factor1, input$factor2)
+    models <- eventReactive(input$run, {
+      req(df(), input$response, input$factor1, input$factor2, input$order1, input$order2)
+      responses <- input$response
+      if (!isTRUE(input$multi_resp)) {
+        responses <- responses[1]
+      }
+      responses <- unique(responses)
+      req(length(responses) > 0)
+
+      if (length(responses) > 10) {
+        validate(need(FALSE, "Please select at most 10 response variables."))
+      }
+
       data <- df()
       data[[input$factor1]] <- factor(data[[input$factor1]], levels = input$order1)
       data[[input$factor2]] <- factor(data[[input$factor2]], levels = input$order2)
-      model_formula <- as.formula(paste(input$response, "~", input$factor1, "*", input$factor2))
-      lm(model_formula, data = data)
-    })
-    
-    # ----------------------------------------------
-    # Outputs — consistent with one-way ANOVA
-    # ----------------------------------------------
-    output$summary <- renderPrint({
-      req(model())
-      summary(model())
-    })
-    
-    output$fixed_effects <- renderDT({
-      req(model())
-      datatable(
-        broom::tidy(model()),
-        options = list(scrollX = TRUE, pageLength = 5),
-        rownames = FALSE
+
+      model_list <- list()
+      for (resp in responses) {
+        model_formula <- as.formula(paste(resp, "~", input$factor1, "*", input$factor2))
+        model_list[[resp]] <- lm(model_formula, data = data)
+      }
+
+      list(
+        models = model_list,
+        responses = responses,
+        factors = list(factor1 = input$factor1, factor2 = input$factor2),
+        orders = list(order1 = input$order1, order2 = input$order2)
       )
     })
-    
-    # Return model reactive for visualization
-    return(model)
+
+    output$summary_ui <- renderUI({
+      model_info <- models()
+      if (is.null(model_info)) {
+        return(NULL)
+      }
+
+      responses <- model_info$responses
+
+      if (length(responses) == 1) {
+        verbatimTextOutput(ns("summary_single"))
+      } else {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(responses[i], verbatimTextOutput(ns(paste0("summary_", i))))
+        })
+        do.call(tabsetPanel, c(list(id = ns("summary_tabs")), tabs))
+      }
+    })
+
+    output$fixed_effects_ui <- renderUI({
+      model_info <- models()
+      if (is.null(model_info)) {
+        return(NULL)
+      }
+
+      responses <- model_info$responses
+
+      if (length(responses) == 1) {
+        DTOutput(ns("fixed_effects_single"))
+      } else {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(responses[i], DTOutput(ns(paste0("fixed_effects_", i))))
+        })
+        do.call(tabsetPanel, c(list(id = ns("fixed_effects_tabs")), tabs))
+      }
+    })
+
+    observeEvent(models(), {
+      model_info <- models()
+      if (is.null(model_info)) {
+        return()
+      }
+
+      responses <- model_info$responses
+      model_list <- model_info$models
+
+      if (length(responses) == 1) {
+        resp <- responses[1]
+        output$summary_single <- renderPrint({
+          summary(model_list[[resp]])
+        })
+        output$fixed_effects_single <- renderDT({
+          datatable(
+            broom::tidy(model_list[[resp]]),
+            options = list(scrollX = TRUE, pageLength = 5),
+            rownames = FALSE
+          )
+        })
+      } else {
+        for (i in seq_along(responses)) {
+          resp <- responses[i]
+          local({
+            idx <- i
+            response_name <- resp
+            output[[paste0("summary_", idx)]] <- renderPrint({
+              summary(model_list[[response_name]])
+            })
+            output[[paste0("fixed_effects_", idx)]] <- renderDT({
+              datatable(
+                broom::tidy(model_list[[response_name]]),
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+          })
+        }
+      }
+    })
+
+    return(models)
   })
 }

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -4,6 +4,7 @@
 library(shiny)
 library(ggplot2)
 library(dplyr)
+library(patchwork)
 
 visualize_ui <- function(id) {
   ns <- NS(id)
@@ -33,6 +34,28 @@ visualize_ui <- function(id) {
         )
       )
     ),
+    fluidRow(
+      column(
+        width = 6,
+        numericInput(
+          ns("grid_rows"),
+          label = "Grid rows (optional)",
+          value = NA,
+          min = 1,
+          step = 1
+        )
+      ),
+      column(
+        width = 6,
+        numericInput(
+          ns("grid_cols"),
+          label = "Grid columns (optional)",
+          value = NA,
+          min = 1,
+          step = 1
+        )
+      )
+    ),
     downloadButton(ns("download_plot"), "Download PNG (300 dpi)"),
     plotOutput(ns("mean_se_plot"))
   )
@@ -41,110 +64,121 @@ visualize_ui <- function(id) {
 visualize_server <- function(id, filtered_data, model_fit) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    
+
     df <- reactive({
       req(filtered_data())
       filtered_data()
     })
-    
-    # -----------------------------------------------------------
-    # Extract variable names from fitted model
-    # -----------------------------------------------------------
-    vars <- reactive({
+
+    model_info <- reactive({
       req(model_fit())
-      form <- formula(model_fit())
-      all_vars <- all.vars(form)
-      
-      # Handle one-way or two-way formulas
-      if (length(all_vars) == 2) {
-        list(response = all_vars[1], factor1 = all_vars[2], factor2 = NULL)
-      } else if (length(all_vars) == 3) {
-        list(response = all_vars[1], factor1 = all_vars[2], factor2 = all_vars[3])
-      } else {
-        stop("Unsupported model structure.")
-      }
+      model_fit()
     })
-    
-    
-    # -----------------------------------------------------------
-    # Compute summary statistics
-    # -----------------------------------------------------------
-    summary_stats <- reactive({
-      req(df(), vars())
+
+    plot_list <- reactive({
+      info <- model_info()
+      if (is.null(info) || is.null(info$models) || length(info$models) == 0) {
+        return(NULL)
+      }
+
       data <- df()
-      resp <- vars()$response
-      f1 <- vars()$factor1
-      f2 <- vars()$factor2
-      
-      if (is.null(f2)) {
-        # One-way ANOVA
-        data |>
-          group_by(.data[[f1]]) |>
-          summarise(
-            mean = mean(.data[[resp]], na.rm = TRUE),
-            se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
-            .groups = "drop"
-          )
-      } else {
-        # Two-way ANOVA
-        data |>
-          group_by(.data[[f1]], .data[[f2]]) |>
-          summarise(
-            mean = mean(.data[[resp]], na.rm = TRUE),
-            se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
-            .groups = "drop"
-          )
+      req(data)
+
+      factor1 <- info$factors$factor1
+      factor2 <- info$factors$factor2
+      order1 <- info$orders$order1
+      order2 <- info$orders$order2
+
+      if (!is.null(factor1) && !is.null(order1)) {
+        data[[factor1]] <- factor(data[[factor1]], levels = order1)
       }
+      if (!is.null(factor2) && !is.null(order2)) {
+        data[[factor2]] <- factor(data[[factor2]], levels = order2)
+      }
+
+      responses <- info$responses
+      plot_objects <- list()
+
+      for (resp in responses) {
+        if (is.null(factor2)) {
+          stats <- data |>
+            group_by(.data[[factor1]]) |>
+            summarise(
+              mean = mean(.data[[resp]], na.rm = TRUE),
+              se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+              .groups = "drop"
+            )
+
+          p <- ggplot(stats, aes_string(x = factor1, y = "mean")) +
+            geom_line(aes(group = 1), color = "steelblue", linewidth = 1) +
+            geom_point(size = 3, color = "steelblue") +
+            geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                          width = 0.15, color = "gray40") +
+            theme_minimal(base_size = 14) +
+            labs(x = factor1, y = "Mean ± SE") +
+            theme(
+              panel.grid.minor = element_blank(),
+              panel.grid.major.x = element_blank()
+            ) +
+            ggtitle(resp)
+        } else {
+          stats <- data |>
+            group_by(.data[[factor1]], .data[[factor2]]) |>
+            summarise(
+              mean = mean(.data[[resp]], na.rm = TRUE),
+              se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+              .groups = "drop"
+            )
+
+          p <- ggplot(stats, aes_string(
+            x = factor1,
+            y = "mean",
+            color = factor2,
+            group = factor2
+          )) +
+            geom_line(linewidth = 1) +
+            geom_point(size = 3) +
+            geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                          width = 0.15) +
+            theme_minimal(base_size = 14) +
+            labs(
+              x = factor1,
+              y = "Mean ± SE",
+              color = factor2
+            ) +
+            theme(
+              panel.grid.minor = element_blank(),
+              panel.grid.major.x = element_blank()
+            ) +
+            ggtitle(resp)
+        }
+
+        plot_objects[[resp]] <- p
+      }
+
+      plot_objects
     })
-    
-    
-    # -----------------------------------------------------------
-    # Plot mean ± SE
-    # -----------------------------------------------------------
+
     plot_obj <- reactive({
-      req(summary_stats(), vars())
-      stats <- summary_stats()
-      f1 <- vars()$factor1
-      f2 <- vars()$factor2
-      
-      if (is.null(f2)) {
-        # One-way plot (same as before)
-        ggplot(stats, aes(x = !!sym(f1), y = mean, group = 1)) +
-          geom_line(color = "steelblue", linewidth = 1) +
-          geom_point(size = 3, color = "steelblue") +
-          geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
-                        width = 0.15, color = "gray40") +
-          theme_minimal(base_size = 14) +
-          labs(x = f1, y = "Mean ± SE") +
-          theme(
-            panel.grid.minor = element_blank(),
-            panel.grid.major.x = element_blank()
-          )
-      } else {
-        # Two-way plot (factor1 on x-axis, factor2 as color)
-        ggplot(stats, aes(
-          x = !!sym(f1),
-          y = mean,
-          color = !!sym(f2),
-          group = !!sym(f2)
-        )) +
-          geom_line(linewidth = 1) +
-          geom_point(size = 3) +
-          geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
-                        width = 0.15) +
-          theme_minimal(base_size = 14) +
-          labs(
-            x = f1,
-            y = "Mean ± SE",
-            color = f2
-          ) +
-          theme(
-            panel.grid.minor = element_blank(),
-            panel.grid.major.x = element_blank()
-          )
+      plots <- plot_list()
+      if (is.null(plots) || length(plots) == 0) {
+        return(NULL)
       }
+
+      n <- length(plots)
+      n_row <- input$grid_rows
+      n_col <- input$grid_cols
+
+      if (is.null(n_row) || is.na(n_row) || n_row < 1) {
+        n_row <- ceiling(sqrt(n))
+      }
+      if (is.null(n_col) || is.na(n_col) || n_col < 1) {
+        n_col <- ceiling(n / n_row)
+      }
+
+      patchwork::wrap_plots(plotlist = plots, nrow = n_row, ncol = n_col)
     })
-    
+
 
     output$mean_se_plot <- renderPlot({
       req(plot_obj())


### PR DESCRIPTION
## Summary
- add UI controls to enable multi-response ANOVA selection with validation and tabbed outputs
- update one-way and two-way ANOVA modules to fit, summarise, and tidy multiple response models and return shared metadata
- enhance visualization module to lay out per-response plots in a configurable grid and export combined figures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68effbc5a9ec832bbe1085e27bdf94b2