### PR TITLE
Move ANOVA configuration controls into sidebar

### DIFF
--- a/R/animal_trial_analyzer/module_analysis.R
+++ b/R/animal_trial_analyzer/module_analysis.R
@@ -9,15 +9,16 @@ source("R/animal_trial_analyzer/module_analysis_utils.R")
 
 analysis_ui <- function(id) {
   ns <- NS(id)
-  tagList(
-    h4("3. Statistical Analysis"),
-    selectInput(
+  list(
+    heading = h4("3. Statistical Analysis"),
+    type_selector = selectInput(
       ns("analysis_type"),
       "Select analysis type:",
       choices = c("One-way ANOVA", "Two-way ANOVA"),  # more will be added here later
       selected = "One-way ANOVA"
     ),
-    uiOutput(ns("analysis_panel"))
+    config_panel = uiOutput(ns("config_panel")),
+    results_panel = uiOutput(ns("results_panel"))
   )
 }
 
@@ -30,16 +31,30 @@ analysis_server <- function(id, filtered_data) {
       filtered_data()
     })
     
-    # Dynamically show the correct submodule based on selection
-    output$analysis_panel <- renderUI({
+    current_module_ui <- reactive({
       req(input$analysis_type)
       if (input$analysis_type == "One-way ANOVA") {
         one_way_anova_ui(ns("anova_one"))
       } else if (input$analysis_type == "Two-way ANOVA") {
         two_way_anova_ui(ns("anova_two"))
       } else {
-        p("Analysis type not implemented yet.")
+        list(
+          config = p("Analysis type not implemented yet."),
+          results = p("Analysis type not implemented yet.")
+        )
       }
+    })
+
+    output$config_panel <- renderUI({
+      ui <- current_module_ui()
+      req(ui$config)
+      ui$config
+    })
+
+    output$results_panel <- renderUI({
+      ui <- current_module_ui()
+      req(ui$results)
+      ui$results
     })
     
     

--- a/R/animal_trial_analyzer/module_analysis_one-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_one-way_anova.R
@@ -7,14 +7,18 @@ library(broom)
 
 one_way_anova_ui <- function(id) {
   ns <- NS(id)
-  tagList(
-    uiOutput(ns("inputs")),
-    uiOutput(ns("level_order")),
-    br(),
-    actionButton(ns("run"), "Run ANOVA"),
-    br(), br(),
-    uiOutput(ns("summary_ui")),
-    uiOutput(ns("fixed_effects_ui"))
+  list(
+    config = tagList(
+      uiOutput(ns("inputs")),
+      uiOutput(ns("level_order")),
+      br(),
+      actionButton(ns("run"), "Run ANOVA")
+    ),
+    results = tagList(
+      uiOutput(ns("summary_ui")),
+      br(),
+      uiOutput(ns("fixed_effects_ui"))
+    )
   )
 }
 

--- a/R/animal_trial_analyzer/module_analysis_two-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_two-way_anova.R
@@ -5,15 +5,19 @@
 
 two_way_anova_ui <- function(id) {
   ns <- NS(id)
-  tagList(
-    uiOutput(ns("inputs")),
-    uiOutput(ns("level_order_1")),
-    uiOutput(ns("level_order_2")),
-    br(),
-    actionButton(ns("run"), "Run Two-way ANOVA"),
-    br(), br(),
-    uiOutput(ns("summary_ui")),
-    uiOutput(ns("fixed_effects_ui"))
+  list(
+    config = tagList(
+      uiOutput(ns("inputs")),
+      uiOutput(ns("level_order_1")),
+      uiOutput(ns("level_order_2")),
+      br(),
+      actionButton(ns("run"), "Run Two-way ANOVA")
+    ),
+    results = tagList(
+      uiOutput(ns("summary_ui")),
+      br(),
+      uiOutput(ns("fixed_effects_ui"))
+    )
   )
 }
 

--- a/animal_trial_analyzer_module.R
+++ b/animal_trial_analyzer_module.R
@@ -79,7 +79,9 @@ animal_trial_app_ui <- function(id) {
               h4("Step 3 — Analyze Results"),
               p("Choose the statistical approach that fits your trial design, then inspect the summaries on the right."),
               hr(),
-              analysis_components[[2]],
+              analysis_components$type_selector,
+              hr(),
+              analysis_components$config_panel,
               hr(),
               div(
                 class = "d-flex justify-content-between gap-2",
@@ -89,8 +91,8 @@ animal_trial_app_ui <- function(id) {
             ),
             mainPanel(
               width = 8,
-              h4("Analysis Configuration & Output"),
-              analysis_components[[3]]
+              h4("Analysis Results"),
+              analysis_components$results_panel
             )
           )
         }


### PR DESCRIPTION
## Summary
- refactor the analysis module UI to separate configuration widgets from results outputs
- update the one-way and two-way ANOVA modules to return dedicated config and results layouts
- render the ANOVA configuration controls in the Analyze tab sidebar while keeping summaries in the main panel

## Testing
- Rscript -e "source('app.R')" *(fails: Rscript not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0171c36c8832ba31bb69d383a28b9