### PR TITLE
Add subgroup-driven analysis and visualization

### DIFF
--- a/R/animal_trial_analyzer/module_analysis_one-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_one-way_anova.R
@@ -39,14 +39,21 @@ one_way_anova_server <- function(id, filtered_data) {
       data <- df()
       num_cols <- names(data)[sapply(data, is.numeric)]
       cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
-      
+
       tagList(
         # --- checkbox always exists ---
         checkboxInput(ns("multi_resp"), "Enable multiple response variables", value = FALSE),
-        
+
         # --- placeholder for response selector ---
         uiOutput(ns("response_selector")),
-        
+
+        selectInput(
+          ns("subgroup_var"),
+          "Subgroup variable (optional):",
+          choices = c("None" = "", cat_cols),
+          selected = ""
+        ),
+
         selectInput(
           ns("group"),
           "Grouping variable (factor):",
@@ -96,6 +103,8 @@ one_way_anova_server <- function(id, filtered_data) {
     })
     
     # Fit model(s)
+    overview_data <- reactiveVal(NULL)
+
     models <- eventReactive(input$run, {
       req(df(), input$response, input$group, input$order)
       responses <- input$response
@@ -112,17 +121,131 @@ one_way_anova_server <- function(id, filtered_data) {
       data <- df()
       data[[input$group]] <- factor(data[[input$group]], levels = input$order)
 
+      subgroup_var <- input$subgroup_var
+      if (!length(subgroup_var) || !nzchar(subgroup_var)) {
+        subgroup_var <- NULL
+      }
+
+      subgroup_levels <- NULL
+      if (!is.null(subgroup_var)) {
+        subgroup_data <- stats::na.omit(data[, subgroup_var, drop = FALSE])
+        subgroup_levels <- unique(as.character(subgroup_data[[subgroup_var]]))
+        if (length(subgroup_levels) > 10) {
+          validate(need(FALSE, "Please select a subgroup variable with at most 10 levels."))
+        }
+      }
+
       model_list <- list()
+      overview_rows <- list()
+
       for (resp in responses) {
         model_formula <- as.formula(paste(resp, "~", input$group))
-        model_list[[resp]] <- lm(model_formula, data = data)
+
+        if (is.null(subgroup_var)) {
+          model_obj <- lm(model_formula, data = data)
+          model_list[[resp]] <- list("Overall" = model_obj)
+
+          glance_row <- tryCatch({
+            broom::glance(model_obj)
+          }, error = function(e) NULL)
+
+          if (!is.null(glance_row)) {
+            overview_rows[[length(overview_rows) + 1]] <- data.frame(
+              Response = resp,
+              Subgroup = "All data",
+              DF = round(glance_row$df, 3),
+              `F value` = round(glance_row$statistic, 3),
+              `p value` = signif(glance_row$p.value, 3),
+              Significance = ifelse(
+                is.na(glance_row$p.value),
+                "",
+                ifelse(glance_row$p.value < 0.001, "***",
+                       ifelse(glance_row$p.value < 0.01, "**",
+                              ifelse(glance_row$p.value < 0.05, "*", "ns")))
+              ),
+              stringsAsFactors = FALSE
+            )
+          }
+        } else {
+          subgroup_models <- list()
+
+          for (lvl in subgroup_levels) {
+            subset_idx <- which(!is.na(data[[subgroup_var]]) & as.character(data[[subgroup_var]]) == lvl)
+            if (length(subset_idx) == 0) {
+              next
+            }
+
+            subset_data <- data[subset_idx, , drop = FALSE]
+            subset_data <- subset_data[!is.na(subset_data[[resp]]), , drop = FALSE]
+            if (nrow(subset_data) == 0) {
+              next
+            }
+
+            model_obj <- tryCatch({
+              lm(model_formula, data = subset_data)
+            }, error = function(e) NULL)
+
+            if (!is.null(model_obj)) {
+              subgroup_models[[lvl]] <- model_obj
+
+              glance_row <- tryCatch({
+                broom::glance(model_obj)
+              }, error = function(e) NULL)
+
+              if (!is.null(glance_row)) {
+                overview_rows[[length(overview_rows) + 1]] <- data.frame(
+                  Response = resp,
+                  Subgroup = lvl,
+                  DF = round(glance_row$df, 3),
+                  `F value` = round(glance_row$statistic, 3),
+                  `p value` = signif(glance_row$p.value, 3),
+                  Significance = ifelse(
+                    is.na(glance_row$p.value),
+                    "",
+                    ifelse(glance_row$p.value < 0.001, "***",
+                           ifelse(glance_row$p.value < 0.01, "**",
+                                  ifelse(glance_row$p.value < 0.05, "*", "ns")))
+                  ),
+                  stringsAsFactors = FALSE
+                )
+              }
+            }
+          }
+
+          if (length(subgroup_models) > 0) {
+            model_list[[resp]] <- subgroup_models
+          }
+        }
+      }
+
+      if (length(model_list) == 0) {
+        validate(need(FALSE, "No models could be fitted for the selected configuration."))
+      }
+
+      if (length(overview_rows) > 0) {
+        overview_df <- do.call(rbind, overview_rows)
+        overview_df$Significance[is.na(overview_df$Significance)] <- ""
+        overview_data(overview_df)
+      } else {
+        overview_data(NULL)
       }
 
       list(
         models = model_list,
-        responses = responses,
+        responses = names(model_list),
+        subgroups = if (is.null(subgroup_var)) character(0) else unique(unlist(lapply(model_list, names))),
+        subgroup_var = subgroup_var,
         factors = list(factor1 = input$group, factor2 = NULL),
         orders = list(order1 = input$order, order2 = NULL)
+      )
+    })
+
+    output$overview_table <- renderDT({
+      req(overview_data())
+      datatable(
+        overview_data(),
+        options = list(pageLength = 5, scrollX = TRUE, dom = "tip"),
+        rownames = FALSE
       )
     })
 
@@ -134,31 +257,87 @@ one_way_anova_server <- function(id, filtered_data) {
       }
 
       responses <- model_info$responses
+      subgroup_var <- model_info$subgroup_var
 
-      tabs <- lapply(seq_along(responses), function(i) {
-        tabPanel(
-          title = responses[i],
-          tags$div(
-            tags$details(
-              open = FALSE,
-              tags$summary(strong("R Output")),
-              verbatimTextOutput(ns(paste0("summary_", i)))
-            ),
-            br(),
-            h4("Coefficient Table"),
-            DTOutput(ns(paste0("fixed_effects_", i))),
-            br(),
-            h4("Download Results"),
-            downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
-          )
+      if (length(responses) == 0) {
+        return(NULL)
+      }
+
+      overview_block <- NULL
+      if (!is.null(overview_data())) {
+        overview_block <- tagList(
+          h4("Overview of Results"),
+          DTOutput(ns("overview_table")),
+          br()
         )
-      })
+      }
 
-      do.call(tabsetPanel, c(list(id = ns("results_tabs")), tabs))
-    })
+      model_list <- model_info$models
 
-    output$fixed_effects_ui <- renderUI({
-      NULL
+      if (is.null(subgroup_var)) {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(
+            title = responses[i],
+            tags$div(
+              h5("Summary"),
+              verbatimTextOutput(ns(paste0("summary_", i, "_1"))),
+              br(),
+              h5("Fixed effects"),
+              DTOutput(ns(paste0("fixed_effects_", i, "_1"))),
+              br(),
+              downloadButton(ns(paste0("download_", i, "_1")), "Download Results (Word)")
+            )
+          )
+        })
+
+        tagList(
+          overview_block,
+          do.call(tabsetPanel, c(list(id = ns("results_tabs")), tabs))
+        )
+      } else {
+        tabs <- lapply(seq_along(responses), function(i) {
+          resp <- responses[i]
+          resp_models <- model_list[[resp]]
+          if (is.null(resp_models) || length(resp_models) == 0) {
+            return(tabPanel(title = resp, tags$p("No data available for this response.")))
+          }
+
+          subgroup_names <- names(resp_models)
+
+          subgroup_tabs <- lapply(seq_along(resp_models), function(j) {
+            tabPanel(
+              title = paste("Subgroup:", subgroup_names[j]),
+              tags$div(
+                h5("Summary"),
+                verbatimTextOutput(ns(paste0("summary_", i, "_", j))),
+                br(),
+                h5("Fixed effects"),
+                DTOutput(ns(paste0("fixed_effects_", i, "_", j))),
+                br(),
+                downloadButton(ns(paste0("download_", i, "_", j)), "Download Results (Word)")
+              )
+            )
+          })
+
+          do.call(
+            tabPanel,
+            c(
+              list(title = resp),
+              list(
+                do.call(
+                  tabsetPanel,
+                  c(list(id = ns(paste0("subtabs_", i))), subgroup_tabs)
+                )
+              )
+            )
+          )
+        })
+
+        tagList(
+          overview_block,
+          do.call(tabsetPanel, c(list(id = ns("response_tabs")), tabs))
+        )
+      }
     })
 
     observeEvent(models(), {
@@ -169,62 +348,92 @@ one_way_anova_server <- function(id, filtered_data) {
 
       responses <- model_info$responses
       model_list <- model_info$models
+      subgroup_var <- model_info$subgroup_var
 
       for (i in seq_along(responses)) {
         resp <- responses[i]
-        local({
-          idx <- i
-          response_name <- resp
-          model_obj <- model_list[[response_name]]
+        resp_models <- model_list[[resp]]
+        if (is.null(resp_models) || length(resp_models) == 0) {
+          next
+        }
 
-          tidy_df <- broom::tidy(model_obj)
-          numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
-          tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+        subgroup_names <- names(resp_models)
 
-          output[[paste0("summary_", idx)]] <- renderPrint({
-            summary(model_obj)
-          })
+        for (j in seq_along(resp_models)) {
+          model_obj <- resp_models[[j]]
+          subgroup_name <- if (!is.null(subgroup_var) && length(subgroup_names) >= j) subgroup_names[j] else NULL
 
-          output[[paste0("fixed_effects_", idx)]] <- renderDT({
-            datatable(
-              tidy_df,
-              options = list(scrollX = TRUE, pageLength = 5),
-              rownames = FALSE
+          local({
+            idx_resp <- i
+            idx_sub <- j
+            response_name <- resp
+            subgroup_label <- subgroup_name
+            model_copy <- model_obj
+
+            tidy_df <- broom::tidy(model_copy)
+            numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
+            tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+
+            output[[paste0("summary_", idx_resp, "_", idx_sub)]] <- renderPrint({
+              summary(model_copy)
+            })
+
+            output[[paste0("fixed_effects_", idx_resp, "_", idx_sub)]] <- renderDT({
+              datatable(
+                tidy_df,
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+
+            output[[paste0("download_", idx_resp, "_", idx_sub)]] <- downloadHandler(
+              filename = function() {
+                safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
+                safe_resp <- gsub("_+", "_", safe_resp)
+                safe_resp <- gsub("^_|_$", "", safe_resp)
+                if (!nzchar(safe_resp)) {
+                  safe_resp <- paste0("response_", idx_resp)
+                }
+
+                if (!is.null(subgroup_label)) {
+                  safe_sub <- gsub("[^A-Za-z0-9]+", "_", subgroup_label)
+                  safe_sub <- gsub("_+", "_", safe_sub)
+                  safe_sub <- gsub("^_|_$", "", safe_sub)
+                  if (nzchar(safe_sub)) {
+                    return(paste0("anova_results_", safe_resp, "_", safe_sub, "_", Sys.Date(), ".docx"))
+                  }
+                }
+
+                paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
+              },
+              content = function(file) {
+                tidy_export <- broom::tidy(model_copy)
+                numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
+                tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
+
+                doc <- officer::read_docx()
+                heading <- if (is.null(subgroup_label)) {
+                  paste("ANOVA results for:", response_name)
+                } else {
+                  paste("ANOVA results for:", response_name, "| Subgroup:", subgroup_label)
+                }
+                doc <- officer::body_add_par(doc, heading, style = "heading 1")
+                doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_copy))), style = "heading 2")
+                doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
+                summary_lines <- capture.output(summary(model_copy))
+                for (line in summary_lines) {
+                  doc <- officer::body_add_par(doc, line, style = "Normal")
+                }
+                doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
+                ft <- flextable::flextable(tidy_export)
+                ft <- flextable::autofit(ft)
+                doc <- officer::body_add_flextable(doc, ft)
+
+                officer::print(doc, target = file)
+              }
             )
           })
-
-          output[[paste0("download_", idx)]] <- downloadHandler(
-            filename = function() {
-              safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
-              safe_resp <- gsub("_+", "_", safe_resp)
-              safe_resp <- gsub("^_|_$", "", safe_resp)
-              if (!nzchar(safe_resp)) {
-                safe_resp <- paste0("response_", idx)
-              }
-              paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
-            },
-            content = function(file) {
-              tidy_export <- broom::tidy(model_obj)
-              numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
-              tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
-
-              doc <- officer::read_docx()
-              doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
-              doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
-              doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
-              summary_lines <- capture.output(summary(model_obj))
-              for (line in summary_lines) {
-                doc <- officer::body_add_par(doc, line, style = "Normal")
-              }
-              doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
-              ft <- flextable::flextable(tidy_export)
-              ft <- flextable::autofit(ft)
-              doc <- officer::body_add_flextable(doc, ft)
-
-              officer::print(doc, target = file)
-            }
-          )
-        })
+        }
       }
     })
 

--- a/R/animal_trial_analyzer/module_analysis_two-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_two-way_anova.R
@@ -46,10 +46,17 @@ two_way_anova_server <- function(id, filtered_data) {
       tagList(
         # checkbox always present
         checkboxInput(ns("multi_resp"), "Enable multiple response variables", value = FALSE),
-        
+
         # placeholder for the response selector that updates reactively
         uiOutput(ns("response_selector")),
-        
+
+        selectInput(
+          ns("subgroup_var"),
+          "Subgroup variable (optional):",
+          choices = c("None" = "", cat_cols),
+          selected = ""
+        ),
+
         selectInput(
           ns("factor1"),
           "First factor (x-axis):",
@@ -121,6 +128,8 @@ two_way_anova_server <- function(id, filtered_data) {
     # ----------------------------------------------
     # Fit two-way ANOVA model (fixed effects output)
     # ----------------------------------------------
+    overview_data <- reactiveVal(NULL)
+
     models <- eventReactive(input$run, {
       req(df(), input$response, input$factor1, input$factor2, input$order1, input$order2)
       responses <- input$response
@@ -138,17 +147,131 @@ two_way_anova_server <- function(id, filtered_data) {
       data[[input$factor1]] <- factor(data[[input$factor1]], levels = input$order1)
       data[[input$factor2]] <- factor(data[[input$factor2]], levels = input$order2)
 
+      subgroup_var <- input$subgroup_var
+      if (!length(subgroup_var) || !nzchar(subgroup_var)) {
+        subgroup_var <- NULL
+      }
+
+      subgroup_levels <- NULL
+      if (!is.null(subgroup_var)) {
+        subgroup_data <- stats::na.omit(data[, subgroup_var, drop = FALSE])
+        subgroup_levels <- unique(as.character(subgroup_data[[subgroup_var]]))
+        if (length(subgroup_levels) > 10) {
+          validate(need(FALSE, "Please select a subgroup variable with at most 10 levels."))
+        }
+      }
+
       model_list <- list()
+      overview_rows <- list()
+
       for (resp in responses) {
         model_formula <- as.formula(paste(resp, "~", input$factor1, "*", input$factor2))
-        model_list[[resp]] <- lm(model_formula, data = data)
+
+        if (is.null(subgroup_var)) {
+          model_obj <- lm(model_formula, data = data)
+          model_list[[resp]] <- list("Overall" = model_obj)
+
+          glance_row <- tryCatch({
+            broom::glance(model_obj)
+          }, error = function(e) NULL)
+
+          if (!is.null(glance_row)) {
+            overview_rows[[length(overview_rows) + 1]] <- data.frame(
+              Response = resp,
+              Subgroup = "All data",
+              DF = round(glance_row$df, 3),
+              `F value` = round(glance_row$statistic, 3),
+              `p value` = signif(glance_row$p.value, 3),
+              Significance = ifelse(
+                is.na(glance_row$p.value),
+                "",
+                ifelse(glance_row$p.value < 0.001, "***",
+                       ifelse(glance_row$p.value < 0.01, "**",
+                              ifelse(glance_row$p.value < 0.05, "*", "ns")))
+              ),
+              stringsAsFactors = FALSE
+            )
+          }
+        } else {
+          subgroup_models <- list()
+
+          for (lvl in subgroup_levels) {
+            subset_idx <- which(!is.na(data[[subgroup_var]]) & as.character(data[[subgroup_var]]) == lvl)
+            if (length(subset_idx) == 0) {
+              next
+            }
+
+            subset_data <- data[subset_idx, , drop = FALSE]
+            subset_data <- subset_data[!is.na(subset_data[[resp]]), , drop = FALSE]
+            if (nrow(subset_data) == 0) {
+              next
+            }
+
+            model_obj <- tryCatch({
+              lm(model_formula, data = subset_data)
+            }, error = function(e) NULL)
+
+            if (!is.null(model_obj)) {
+              subgroup_models[[lvl]] <- model_obj
+
+              glance_row <- tryCatch({
+                broom::glance(model_obj)
+              }, error = function(e) NULL)
+
+              if (!is.null(glance_row)) {
+                overview_rows[[length(overview_rows) + 1]] <- data.frame(
+                  Response = resp,
+                  Subgroup = lvl,
+                  DF = round(glance_row$df, 3),
+                  `F value` = round(glance_row$statistic, 3),
+                  `p value` = signif(glance_row$p.value, 3),
+                  Significance = ifelse(
+                    is.na(glance_row$p.value),
+                    "",
+                    ifelse(glance_row$p.value < 0.001, "***",
+                           ifelse(glance_row$p.value < 0.01, "**",
+                                  ifelse(glance_row$p.value < 0.05, "*", "ns")))
+                  ),
+                  stringsAsFactors = FALSE
+                )
+              }
+            }
+          }
+
+          if (length(subgroup_models) > 0) {
+            model_list[[resp]] <- subgroup_models
+          }
+        }
+      }
+
+      if (length(model_list) == 0) {
+        validate(need(FALSE, "No models could be fitted for the selected configuration."))
+      }
+
+      if (length(overview_rows) > 0) {
+        overview_df <- do.call(rbind, overview_rows)
+        overview_df$Significance[is.na(overview_df$Significance)] <- ""
+        overview_data(overview_df)
+      } else {
+        overview_data(NULL)
       }
 
       list(
         models = model_list,
-        responses = responses,
+        responses = names(model_list),
+        subgroups = if (is.null(subgroup_var)) character(0) else unique(unlist(lapply(model_list, names))),
+        subgroup_var = subgroup_var,
         factors = list(factor1 = input$factor1, factor2 = input$factor2),
         orders = list(order1 = input$order1, order2 = input$order2)
+      )
+    })
+
+    output$overview_table <- renderDT({
+      req(overview_data())
+      datatable(
+        overview_data(),
+        options = list(pageLength = 5, scrollX = TRUE, dom = "tip"),
+        rownames = FALSE
       )
     })
 
@@ -159,31 +282,87 @@ two_way_anova_server <- function(id, filtered_data) {
       }
 
       responses <- model_info$responses
+      subgroup_var <- model_info$subgroup_var
 
-      tabs <- lapply(seq_along(responses), function(i) {
-        tabPanel(
-          title = responses[i],
-          tags$div(
-            tags$details(
-              open = FALSE,
-              tags$summary(strong("R Output")),
-              verbatimTextOutput(ns(paste0("summary_", i)))
-            ),
-            br(),
-            h4("Coefficient Table"),
-            DTOutput(ns(paste0("fixed_effects_", i))),
-            br(),
-            h4("Download Results"),
-            downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
-          )
+      if (length(responses) == 0) {
+        return(NULL)
+      }
+
+      overview_block <- NULL
+      if (!is.null(overview_data())) {
+        overview_block <- tagList(
+          h4("Overview of Results"),
+          DTOutput(ns("overview_table")),
+          br()
         )
-      })
+      }
 
-      do.call(tabsetPanel, c(list(id = ns("results_tabs")), tabs))
-    })
+      model_list <- model_info$models
 
-    output$fixed_effects_ui <- renderUI({
-      NULL
+      if (is.null(subgroup_var)) {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(
+            title = responses[i],
+            tags$div(
+              h5("Summary"),
+              verbatimTextOutput(ns(paste0("summary_", i, "_1"))),
+              br(),
+              h5("Fixed effects"),
+              DTOutput(ns(paste0("fixed_effects_", i, "_1"))),
+              br(),
+              downloadButton(ns(paste0("download_", i, "_1")), "Download Results (Word)")
+            )
+          )
+        })
+
+        tagList(
+          overview_block,
+          do.call(tabsetPanel, c(list(id = ns("results_tabs")), tabs))
+        )
+      } else {
+        tabs <- lapply(seq_along(responses), function(i) {
+          resp <- responses[i]
+          resp_models <- model_list[[resp]]
+          if (is.null(resp_models) || length(resp_models) == 0) {
+            return(tabPanel(title = resp, tags$p("No data available for this response.")))
+          }
+
+          subgroup_names <- names(resp_models)
+
+          subgroup_tabs <- lapply(seq_along(resp_models), function(j) {
+            tabPanel(
+              title = paste("Subgroup:", subgroup_names[j]),
+              tags$div(
+                h5("Summary"),
+                verbatimTextOutput(ns(paste0("summary_", i, "_", j))),
+                br(),
+                h5("Fixed effects"),
+                DTOutput(ns(paste0("fixed_effects_", i, "_", j))),
+                br(),
+                downloadButton(ns(paste0("download_", i, "_", j)), "Download Results (Word)")
+              )
+            )
+          })
+
+          do.call(
+            tabPanel,
+            c(
+              list(title = resp),
+              list(
+                do.call(
+                  tabsetPanel,
+                  c(list(id = ns(paste0("subtabs_", i))), subgroup_tabs)
+                )
+              )
+            )
+          )
+        })
+
+        tagList(
+          overview_block,
+          do.call(tabsetPanel, c(list(id = ns("response_tabs")), tabs))
+        )
+      }
     })
 
     observeEvent(models(), {
@@ -194,62 +373,92 @@ two_way_anova_server <- function(id, filtered_data) {
 
       responses <- model_info$responses
       model_list <- model_info$models
+      subgroup_var <- model_info$subgroup_var
 
       for (i in seq_along(responses)) {
         resp <- responses[i]
-        local({
-          idx <- i
-          response_name <- resp
-          model_obj <- model_list[[response_name]]
+        resp_models <- model_list[[resp]]
+        if (is.null(resp_models) || length(resp_models) == 0) {
+          next
+        }
 
-          tidy_df <- broom::tidy(model_obj)
-          numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
-          tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+        subgroup_names <- names(resp_models)
 
-          output[[paste0("summary_", idx)]] <- renderPrint({
-            summary(model_obj)
-          })
+        for (j in seq_along(resp_models)) {
+          model_obj <- resp_models[[j]]
+          subgroup_name <- if (!is.null(subgroup_var) && length(subgroup_names) >= j) subgroup_names[j] else NULL
 
-          output[[paste0("fixed_effects_", idx)]] <- renderDT({
-            datatable(
-              tidy_df,
-              options = list(scrollX = TRUE, pageLength = 5),
-              rownames = FALSE
+          local({
+            idx_resp <- i
+            idx_sub <- j
+            response_name <- resp
+            subgroup_label <- subgroup_name
+            model_copy <- model_obj
+
+            tidy_df <- broom::tidy(model_copy)
+            numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
+            tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+
+            output[[paste0("summary_", idx_resp, "_", idx_sub)]] <- renderPrint({
+              summary(model_copy)
+            })
+
+            output[[paste0("fixed_effects_", idx_resp, "_", idx_sub)]] <- renderDT({
+              datatable(
+                tidy_df,
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+
+            output[[paste0("download_", idx_resp, "_", idx_sub)]] <- downloadHandler(
+              filename = function() {
+                safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
+                safe_resp <- gsub("_+", "_", safe_resp)
+                safe_resp <- gsub("^_|_$", "", safe_resp)
+                if (!nzchar(safe_resp)) {
+                  safe_resp <- paste0("response_", idx_resp)
+                }
+
+                if (!is.null(subgroup_label)) {
+                  safe_sub <- gsub("[^A-Za-z0-9]+", "_", subgroup_label)
+                  safe_sub <- gsub("_+", "_", safe_sub)
+                  safe_sub <- gsub("^_|_$", "", safe_sub)
+                  if (nzchar(safe_sub)) {
+                    return(paste0("anova_results_", safe_resp, "_", safe_sub, "_", Sys.Date(), ".docx"))
+                  }
+                }
+
+                paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
+              },
+              content = function(file) {
+                tidy_export <- broom::tidy(model_copy)
+                numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
+                tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
+
+                doc <- officer::read_docx()
+                heading <- if (is.null(subgroup_label)) {
+                  paste("ANOVA results for:", response_name)
+                } else {
+                  paste("ANOVA results for:", response_name, "| Subgroup:", subgroup_label)
+                }
+                doc <- officer::body_add_par(doc, heading, style = "heading 1")
+                doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_copy))), style = "heading 2")
+                doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
+                summary_lines <- capture.output(summary(model_copy))
+                for (line in summary_lines) {
+                  doc <- officer::body_add_par(doc, line, style = "Normal")
+                }
+                doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
+                ft <- flextable::flextable(tidy_export)
+                ft <- flextable::autofit(ft)
+                doc <- officer::body_add_flextable(doc, ft)
+
+                officer::print(doc, target = file)
+              }
             )
           })
-
-          output[[paste0("download_", idx)]] <- downloadHandler(
-            filename = function() {
-              safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
-              safe_resp <- gsub("_+", "_", safe_resp)
-              safe_resp <- gsub("^_|_$", "", safe_resp)
-              if (!nzchar(safe_resp)) {
-                safe_resp <- paste0("response_", idx)
-              }
-              paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
-            },
-            content = function(file) {
-              tidy_export <- broom::tidy(model_obj)
-              numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
-              tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
-
-              doc <- officer::read_docx()
-              doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
-              doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
-              doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
-              summary_lines <- capture.output(summary(model_obj))
-              for (line in summary_lines) {
-                doc <- officer::body_add_par(doc, line, style = "Normal")
-              }
-              doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
-              ft <- flextable::flextable(tidy_export)
-              ft <- flextable::autofit(ft)
-              doc <- officer::body_add_flextable(doc, ft)
-
-              officer::print(doc, target = file)
-            }
-          )
-        })
+        }
       }
     })
 

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -10,6 +10,14 @@ visualize_ui <- function(id) {
   ns <- NS(id)
   tagList(
     h4("4. Visualization"),
+    uiOutput(ns("subgroup_selector")),
+    radioButtons(
+      ns("display_mode"),
+      label = "Display mode:",
+      choices = c("Single response tabs" = "single", "All responses in one panel" = "multi"),
+      selected = "single",
+      inline = TRUE
+    ),
     fluidRow(
       column(
         width = 6,
@@ -55,7 +63,7 @@ visualize_ui <- function(id) {
       )
     ),
     downloadButton(ns("download_plot"), "Download PNG (300 dpi)"),
-    plotOutput(ns("mean_se_plot"))
+    uiOutput(ns("plot_container"))
   )
 }
 
@@ -67,10 +75,43 @@ visualize_server <- function(id, filtered_data, model_fit) {
       req(filtered_data())
       filtered_data()
     })
-    
+
+    output$subgroup_selector <- renderUI({
+      req(df())
+      data <- df()
+      cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
+      selected_value <- input$subgroup_var
+      if (is.null(selected_value) || !(selected_value %in% cat_cols)) {
+        selected_value <- ""
+      }
+
+      selectInput(
+        ns("subgroup_var"),
+        "Subgroup variable (optional):",
+        choices = c("None" = "", cat_cols),
+        selected = selected_value
+      )
+    })
+
     model_info <- reactive({
       req(model_fit())
       model_fit()
+    })
+
+    subgroup_details <- reactive({
+      req(df())
+      var <- input$subgroup_var
+      if (is.null(var) || !nzchar(var)) {
+        return(NULL)
+      }
+
+      data <- df()
+      if (!(var %in% names(data))) {
+        return(NULL)
+      }
+
+      levels <- unique(as.character(stats::na.omit(data[[var]])))
+      list(var = var, levels = levels)
     })
     
     plot_list <- reactive({
@@ -78,153 +119,407 @@ visualize_server <- function(id, filtered_data, model_fit) {
       if (is.null(info) || is.null(info$models) || length(info$models) == 0) {
         return(NULL)
       }
-      
+
       data <- df()
       req(data)
-      
+
       factor1 <- info$factors$factor1
       factor2 <- info$factors$factor2
       order1 <- info$orders$order1
       order2 <- info$orders$order2
-      
+
       if (!is.null(factor1) && !is.null(order1)) {
         data[[factor1]] <- factor(data[[factor1]], levels = order1)
       }
       if (!is.null(factor2) && !is.null(order2)) {
         data[[factor2]] <- factor(data[[factor2]], levels = order2)
       }
-      
+
+      subgroup_info <- subgroup_details()
+      subgroup_var <- NULL
+      subgroup_levels <- NULL
+      if (!is.null(subgroup_info)) {
+        subgroup_var <- subgroup_info$var
+        subgroup_levels <- subgroup_info$levels
+        if (length(subgroup_levels) > 10) {
+          validate(need(FALSE, "Please select a subgroup variable with at most 10 categories."))
+        }
+      }
+
       responses <- info$responses
       plot_objects <- list()
-      
+
       for (resp in responses) {
-        if (is.null(factor2)) {
-          stats <- data |>
-            group_by(.data[[factor1]]) |>
-            summarise(
-              mean = mean(.data[[resp]], na.rm = TRUE),
-              se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
-              .groups = "drop"
-            )
-          
-          p <- ggplot(stats, aes_string(x = factor1, y = "mean")) +
-            geom_line(aes(group = 1), color = "steelblue", linewidth = 1) +
-            geom_point(size = 3, color = "steelblue") +
-            geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
-                          width = 0.15, color = "gray40") +
-            theme_minimal(base_size = 14) +
-            labs(x = factor1, y = "Mean ± SE") +
-            theme(
-              panel.grid.minor = element_blank(),
-              panel.grid.major.x = element_blank()
-            ) +
-            ggtitle(resp)
-        } else {
-          stats <- data |>
-            group_by(.data[[factor1]], .data[[factor2]]) |>
-            summarise(
-              mean = mean(.data[[resp]], na.rm = TRUE),
-              se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
-              .groups = "drop"
-            )
-          
-          p <- ggplot(stats, aes_string(
-            x = factor1,
-            y = "mean",
-            color = factor2,
-            group = factor2
-          )) +
-            geom_line(linewidth = 1) +
-            geom_point(size = 3) +
-            geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
-                          width = 0.15) +
-            theme_minimal(base_size = 14) +
-            labs(
-              x = factor1,
-              y = "Mean ± SE",
-              color = factor2
-            ) +
-            theme(
-              panel.grid.minor = element_blank(),
-              panel.grid.major.x = element_blank()
-            ) +
-            ggtitle(resp)
+        resp_data <- data
+        resp_data <- resp_data[!is.na(resp_data[[resp]]), , drop = FALSE]
+        if (!is.null(subgroup_var)) {
+          resp_data <- resp_data[!is.na(resp_data[[subgroup_var]]), , drop = FALSE]
         }
-        
+
+        if (nrow(resp_data) == 0) {
+          next
+        }
+
+        if (is.null(factor2)) {
+          if (is.null(subgroup_var)) {
+            stats <- resp_data |>
+              group_by(.data[[factor1]]) |>
+              summarise(
+                mean = mean(.data[[resp]], na.rm = TRUE),
+                se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+                .groups = "drop"
+              )
+          } else {
+            stats <- resp_data |>
+              group_by(.data[[subgroup_var]], .data[[factor1]]) |>
+              summarise(
+                mean = mean(.data[[resp]], na.rm = TRUE),
+                se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+                .groups = "drop"
+              )
+          }
+
+          if (nrow(stats) == 0) {
+            next
+          }
+
+          if (is.null(subgroup_var)) {
+            p <- ggplot(stats, aes_string(x = factor1, y = "mean")) +
+              geom_line(aes(group = 1), color = "steelblue", linewidth = 1) +
+              geom_point(size = 3, color = "steelblue") +
+              geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                            width = 0.15, color = "gray40") +
+              theme_minimal(base_size = 14) +
+              labs(x = factor1, y = "Mean ± SE") +
+              theme(
+                panel.grid.minor = element_blank(),
+                panel.grid.major.x = element_blank()
+              ) +
+              ggtitle(resp)
+          } else {
+            available_levels <- unique(as.character(stats[[subgroup_var]]))
+            available_levels <- subgroup_levels[subgroup_levels %in% available_levels]
+            if (length(available_levels) == 0) {
+              next
+            }
+
+            stats$subgroup_label <- factor(
+              paste0("Subgroup: ", stats[[subgroup_var]]),
+              levels = paste0("Subgroup: ", available_levels)
+            )
+
+            facet_rows <- if (length(available_levels) <= 5) 1 else 2
+
+            p <- ggplot(stats, aes_string(x = factor1, y = "mean")) +
+              geom_line(aes(group = 1), color = "steelblue", linewidth = 1) +
+              geom_point(size = 3, color = "steelblue") +
+              geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                            width = 0.15, color = "gray40") +
+              theme_minimal(base_size = 14) +
+              labs(x = factor1, y = "Mean ± SE") +
+              theme(
+                panel.grid.minor = element_blank(),
+                panel.grid.major.x = element_blank()
+              ) +
+              ggtitle(resp) +
+              facet_wrap(~ subgroup_label, scales = "fixed", nrow = facet_rows)
+          }
+        } else {
+          if (is.null(subgroup_var)) {
+            stats <- resp_data |>
+              group_by(.data[[factor1]], .data[[factor2]]) |>
+              summarise(
+                mean = mean(.data[[resp]], na.rm = TRUE),
+                se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+                .groups = "drop"
+              )
+          } else {
+            stats <- resp_data |>
+              group_by(.data[[subgroup_var]], .data[[factor1]], .data[[factor2]]) |>
+              summarise(
+                mean = mean(.data[[resp]], na.rm = TRUE),
+                se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+                .groups = "drop"
+              )
+          }
+
+          if (nrow(stats) == 0) {
+            next
+          }
+
+          if (is.null(subgroup_var)) {
+            p <- ggplot(stats, aes_string(
+              x = factor1,
+              y = "mean",
+              color = factor2,
+              group = factor2
+            )) +
+              geom_line(linewidth = 1) +
+              geom_point(size = 3) +
+              geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                            width = 0.15) +
+              theme_minimal(base_size = 14) +
+              labs(
+                x = factor1,
+                y = "Mean ± SE",
+                color = factor2
+              ) +
+              theme(
+                panel.grid.minor = element_blank(),
+                panel.grid.major.x = element_blank()
+              ) +
+              ggtitle(resp)
+          } else {
+            available_levels <- unique(as.character(stats[[subgroup_var]]))
+            available_levels <- subgroup_levels[subgroup_levels %in% available_levels]
+            if (length(available_levels) == 0) {
+              next
+            }
+
+            stats$subgroup_label <- factor(
+              paste0("Subgroup: ", stats[[subgroup_var]]),
+              levels = paste0("Subgroup: ", available_levels)
+            )
+
+            facet_rows <- if (length(available_levels) <= 5) 1 else 2
+
+            p <- ggplot(stats, aes_string(
+              x = factor1,
+              y = "mean",
+              color = factor2,
+              group = factor2
+            )) +
+              geom_line(linewidth = 1) +
+              geom_point(size = 3) +
+              geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                            width = 0.15) +
+              theme_minimal(base_size = 14) +
+              labs(
+                x = factor1,
+                y = "Mean ± SE",
+                color = factor2
+              ) +
+              theme(
+                panel.grid.minor = element_blank(),
+                panel.grid.major.x = element_blank()
+              ) +
+              ggtitle(resp) +
+              facet_wrap(~ subgroup_label, scales = "fixed", nrow = facet_rows)
+          }
+        }
+
         plot_objects[[resp]] <- p
       }
-      
+
+      if (length(plot_objects) == 0) {
+        return(list())
+      }
+
+      if (is.null(names(plot_objects))) {
+        names(plot_objects) <- paste0("Response_", seq_along(plot_objects))
+      }
+
       plot_objects
     })
     
-    # Combine plots and compute grid layout
+    # Combine plots for multi-display mode
     plot_obj <- reactive({
       plots <- plot_list()
       if (is.null(plots) || length(plots) == 0) {
         return(NULL)
       }
-      
+
+      if (!identical(input$display_mode, "multi")) {
+        return(NULL)
+      }
+
       n <- length(plots)
       n_row <- suppressWarnings(as.numeric(input$grid_rows))
       n_col <- suppressWarnings(as.numeric(input$grid_cols))
-      
+
       if (is.na(n_row) || n_row < 1) n_row <- ceiling(sqrt(n))
       if (is.na(n_col) || n_col < 1) n_col <- ceiling(n / n_row)
-      
+
       patchwork::wrap_plots(plotlist = plots, nrow = n_row, ncol = n_col)
     })
-    
+
     # ---- Dynamic sizing logic (pixels) ----
     plot_size <- reactive({
-      n <- length(plot_list())
+      plots <- plot_list()
       w_sub <- input$subplot_width
       h_sub <- input$subplot_height
-      
-      if (is.null(n) || n == 0) return(list(w = w_sub, h = h_sub))
-      if (n == 1) return(list(w = w_sub, h = h_sub))
-      
+
+      if (is.null(plots) || length(plots) == 0) {
+        return(list(w = w_sub, h = h_sub))
+      }
+
+      if (!identical(input$display_mode, "multi") || length(plots) == 1) {
+        return(list(w = w_sub, h = h_sub))
+      }
+
+      n <- length(plots)
       n_row <- suppressWarnings(as.numeric(input$grid_rows))
       n_col <- suppressWarnings(as.numeric(input$grid_cols))
       if (is.na(n_row) || n_row < 1) n_row <- ceiling(sqrt(n))
       if (is.na(n_col) || n_col < 1) n_col <- ceiling(n / n_row)
-      
+
       list(
         w = w_sub * n_col,
         h = h_sub * n_row
       )
     })
-    
-    
-    
-    # ---- Render Plot ----
-    output$mean_se_plot <- renderPlot({
+
+    output$plot_container <- renderUI({
+      plots <- plot_list()
+      if (is.null(plots)) {
+        return(NULL)
+      }
+
+      if (length(plots) == 0) {
+        return(tags$p("No plots available for the selected configuration."))
+      }
+
+      responses <- names(plots)
+      if (length(responses) == 0) {
+        responses <- paste("Response", seq_along(plots))
+      }
+
+      if (identical(input$display_mode, "single")) {
+        tabs <- lapply(seq_along(plots), function(i) {
+          tabPanel(
+            title = responses[i],
+            plotOutput(ns(paste0("plot_", i)))
+          )
+        })
+
+        return(do.call(tabsetPanel, c(list(id = ns("response_plots")), tabs)))
+      }
+
+      plotOutput(ns("combined_plot"), res = 96)
+    })
+
+    observeEvent(plot_list(), {
+      plots <- plot_list()
+      if (is.null(plots) || length(plots) == 0) {
+        return()
+      }
+
+      responses <- names(plots)
+      if (length(responses) == 0) {
+        responses <- paste("Response", seq_along(plots))
+      }
+
+      for (i in seq_along(plots)) {
+        response_id <- responses[i]
+        local({
+          idx <- i
+          resp_name <- response_id
+          output[[paste0("plot_", idx)]] <- renderPlot({
+            req(identical(input$display_mode, "single"))
+            plots_current <- plot_list()
+            if (is.null(plots_current) || length(plots_current) == 0) {
+              return(NULL)
+            }
+
+            plot_names <- names(plots_current)
+            target_name <- resp_name
+            if (!is.null(plot_names) && length(plot_names) >= idx) {
+              if (!(target_name %in% plot_names)) {
+                target_name <- plot_names[idx]
+              }
+            } else if (!is.null(plot_names) && length(plot_names) > 0) {
+              target_name <- plot_names[min(idx, length(plot_names))]
+            }
+
+            plot_to_draw <- plots_current[[target_name]]
+            req(plot_to_draw)
+            plot_to_draw
+          },
+          width = function() input$subplot_width,
+          height = function() input$subplot_height,
+          res = 96)
+        })
+      }
+    })
+
+    output$combined_plot <- renderPlot({
+      req(identical(input$display_mode, "multi"))
       req(plot_obj())
       plot_obj()
     },
     width = function() plot_size()$w,
     height = function() plot_size()$h,
     res = 96)
-    
+
     # ---- Download Plot ----
     output$download_plot <- downloadHandler(
       filename = function() {
-        paste0("mean_se_plot_", Sys.Date(), ".png")
+        plots <- plot_list()
+        req(!is.null(plots), length(plots) > 0)
+
+        if (identical(input$display_mode, "single")) {
+          responses <- names(plots)
+          active <- input$response_plots
+          if (is.null(active) || !nzchar(active) || !(active %in% responses)) {
+            active <- if (length(responses) > 0) responses[1] else names(plots)[1]
+          }
+
+          safe_resp <- gsub("[^A-Za-z0-9]+", "_", active)
+          safe_resp <- gsub("_+", "_", safe_resp)
+          safe_resp <- gsub("^_|_$", "", safe_resp)
+          if (!nzchar(safe_resp)) {
+            safe_resp <- paste0("response_", 1)
+          }
+
+          paste0("mean_se_plot_", safe_resp, "_", Sys.Date(), ".png")
+        } else {
+          paste0("mean_se_plot_composite_", Sys.Date(), ".png")
+        }
       },
       content = function(file) {
-        req(plot_obj())
-        s <- plot_size()
-        width_in  <- s$w / 96
-        height_in <- s$h / 96
-        ggsave(
-          filename = file,
-          plot = plot_obj(),
-          device = "png",
-          dpi = 300,
-          width = width_in,
-          height = height_in,
-          units = "in",
-          limitsize = FALSE
-        )
+        plots <- plot_list()
+        req(!is.null(plots), length(plots) > 0)
+
+        if (identical(input$display_mode, "single")) {
+          responses <- names(plots)
+          active <- input$response_plots
+          if (is.null(active) || !nzchar(active) || !(active %in% responses)) {
+            active <- if (length(responses) > 0) responses[1] else names(plots)[1]
+          }
+
+          plot_to_save <- plots[[active]]
+          req(plot_to_save)
+
+          width_in <- input$subplot_width / 96
+          height_in <- input$subplot_height / 96
+
+          ggsave(
+            filename = file,
+            plot = plot_to_save,
+            device = "png",
+            dpi = 300,
+            width = width_in,
+            height = height_in,
+            units = "in",
+            limitsize = FALSE
+          )
+        } else {
+          req(plot_obj())
+          dims <- plot_size()
+          width_in <- dims$w / 96
+          height_in <- dims$h / 96
+
+          ggsave(
+            filename = file,
+            plot = plot_obj(),
+            device = "png",
+            dpi = 300,
+            width = width_in,
+            height = height_in,
+            units = "in",
+            limitsize = FALSE
+          )
+        }
       }
     )
   })


### PR DESCRIPTION
## Summary
- add optional subgroup selection and per-subgroup ANOVA modeling with overview tables in both analysis modules
- update visualization module with subgroup-aware faceting, single/multi display modes, and revised download handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f08bc3cef8832ba2f7a281b48bb691