### PR TITLE
Centralize analyzer library imports

### DIFF
--- a/R/animal_trial_analyzer/module_analysis.R
+++ b/R/animal_trial_analyzer/module_analysis.R
@@ -1,8 +1,6 @@
 # ===============================================================
 # 🧪 Animal Trial Analyzer — Analysis Coordinator
 # ===============================================================
-library(shiny)
-
 source("R/animal_trial_analyzer/module_analysis_one-way_anova.R")
 source("R/animal_trial_analyzer/module_analysis_two-way_anova.R")
 source("R/animal_trial_analyzer/module_analysis_utils.R")

--- a/R/animal_trial_analyzer/module_analysis_one-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_one-way_anova.R
@@ -1,12 +1,6 @@
 # ===============================================================
 # 🧪 Animal Trial Analyzer — One-way ANOVA
 # ===============================================================
-library(shiny)
-library(DT)
-library(broom)
-library(officer)
-library(flextable)
-
 one_way_anova_ui <- function(id) {
   ns <- NS(id)
   list(

--- a/R/animal_trial_analyzer/module_analysis_two-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_two-way_anova.R
@@ -1,13 +1,6 @@
 # ===============================================================
 # 🧪 Animal Trial Analyzer — Two-way ANOVA Module
 # ===============================================================
-
-library(shiny)
-library(DT)
-library(broom)
-library(officer)
-library(flextable)
-
 two_way_anova_ui <- function(id) {
   ns <- NS(id)
   list(

--- a/R/animal_trial_analyzer/module_filter.R
+++ b/R/animal_trial_analyzer/module_filter.R
@@ -1,9 +1,6 @@
 # ===============================================================
 # 🧪 Animal Trial Analyzer — Filter Module
 # ===============================================================
-library(shiny)
-library(DT)
-
 filter_ui <- function(id) {
   ns <- NS(id)
   tagList(

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -1,11 +1,6 @@
 # ===============================================================
 # 🧪 Animal Trial Analyzer — Visualization Module (Simplified adaptive sizing)
 # ===============================================================
-library(shiny)
-library(ggplot2)
-library(dplyr)
-library(patchwork)
-
 visualize_ui <- function(id) {
   ns <- NS(id)
   tagList(

--- a/app.R
+++ b/app.R
@@ -5,6 +5,12 @@ library(DT)
 library(tools)
 library(broom)
 library(janitor)
+library(data.table)
+library(ggplot2)
+library(dplyr)
+library(patchwork)
+library(officer)
+library(flextable)
 
 options(shiny.autoreload = TRUE)
 


### PR DESCRIPTION
## Summary
- add all packages required by the animal trial analyzer modules to `app.R`
- remove module-level `library()` calls so every dependency is declared in one place

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0b3587190832baf7ce3b90abf649d