### PR TITLE
Add stratified ANOVA support and enhanced visualization layouts

### DIFF
--- a/R/animal_trial_analyzer/module_analysis_one-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_one-way_anova.R
@@ -7,6 +7,7 @@ one_way_anova_ui <- function(id) {
     config = tagList(
       uiOutput(ns("inputs")),
       uiOutput(ns("level_order")),
+      uiOutput(ns("advanced_options")),
       br(),
       actionButton(ns("run"), "Run ANOVA")
     ),
@@ -49,7 +50,25 @@ one_way_anova_server <- function(id, filtered_data) {
         )
       )
     })
-    
+
+    output$advanced_options <- renderUI({
+      req(df())
+      data <- df()
+      cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
+      choices <- c("None", setdiff(unique(cat_cols), "None"))
+
+      tags$details(
+        open = FALSE,
+        tags$summary(strong("Advanced options")),
+        selectInput(
+          ns("stratify_var"),
+          "Stratify analysis by (optional):",
+          choices = choices,
+          selected = "None"
+        )
+      )
+    })
+
     # --- render response selector reactively ---
     output$response_selector <- renderUI({
       req(df())
@@ -92,6 +111,7 @@ one_way_anova_server <- function(id, filtered_data) {
     # Fit model(s)
     models <- eventReactive(input$run, {
       req(df(), input$response, input$group, input$order)
+      req(!is.null(input$stratify_var))
       responses <- input$response
       if (!isTRUE(input$multi_resp)) {
         responses <- responses[1]
@@ -106,15 +126,49 @@ one_way_anova_server <- function(id, filtered_data) {
       data <- df()
       data[[input$group]] <- factor(data[[input$group]], levels = input$order)
 
+      strat_var <- input$stratify_var
+
+      if (is.null(strat_var) || identical(strat_var, "None")) {
+        model_list <- list()
+        for (resp in responses) {
+          model_formula <- as.formula(paste(resp, "~", input$group))
+          model_list[[resp]] <- lm(model_formula, data = data)
+        }
+
+        return(list(
+          models = model_list,
+          responses = responses,
+          strata = NULL,
+          factors = list(factor1 = input$group, factor2 = NULL),
+          orders = list(order1 = input$order, order2 = NULL)
+        ))
+      }
+
+      strata <- unique(as.character(stats::na.omit(data[[strat_var]])))
+      if (length(strata) == 0) {
+        validate(need(FALSE, "No valid strata found for the selected variable."))
+      }
+
+      if (length(strata) > 10) {
+        validate(need(FALSE, "Stratified analysis supports up to 10 strata."))
+      }
+
       model_list <- list()
-      for (resp in responses) {
-        model_formula <- as.formula(paste(resp, "~", input$group))
-        model_list[[resp]] <- lm(model_formula, data = data)
+      for (stratum in strata) {
+        subset_data <- data[data[[strat_var]] == stratum, , drop = FALSE]
+        subset_data[[input$group]] <- factor(subset_data[[input$group]], levels = input$order)
+
+        model_list[[stratum]] <- list()
+        for (resp in responses) {
+          model_formula <- as.formula(paste(resp, "~", input$group))
+          model_list[[stratum]][[resp]] <- lm(model_formula, data = subset_data)
+        }
       }
 
       list(
         models = model_list,
         responses = responses,
+        strata = list(var = strat_var, levels = strata),
         factors = list(factor1 = input$group, factor2 = NULL),
         orders = list(order1 = input$order, order2 = NULL)
       )
@@ -128,23 +182,60 @@ one_way_anova_server <- function(id, filtered_data) {
       }
 
       responses <- model_info$responses
+      strata_info <- model_info$strata
 
-      tabs <- lapply(seq_along(responses), function(i) {
-        tabPanel(
-          title = responses[i],
-          tags$div(
-            tags$details(
-              open = FALSE,
-              tags$summary(strong("R Output")),
-              verbatimTextOutput(ns(paste0("summary_", i)))
-            ),
-            br(),
-            h4("Coefficient Table"),
-            DTOutput(ns(paste0("fixed_effects_", i))),
-            br(),
-            h4("Download Results"),
-            downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
+      if (is.null(strata_info)) {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(
+            title = responses[i],
+            tags$div(
+              tags$details(
+                open = FALSE,
+                tags$summary(strong("R Output")),
+                verbatimTextOutput(ns(paste0("summary_", i)))
+              ),
+              br(),
+              h4("Coefficient Table"),
+              DTOutput(ns(paste0("fixed_effects_", i))),
+              br(),
+              h4("Download Results"),
+              downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
+            )
           )
+        })
+
+        return(do.call(tabsetPanel, c(list(id = ns("results_tabs")), tabs)))
+      }
+
+      strata_levels <- strata_info$levels
+      tabs <- lapply(seq_along(responses), function(i) {
+        response_name <- responses[i]
+        stratum_tabs <- lapply(seq_along(strata_levels), function(j) {
+          stratum_name <- strata_levels[j]
+          tabPanel(
+            title = stratum_name,
+            tags$div(
+              tags$details(
+                open = FALSE,
+                tags$summary(strong("R Output")),
+                verbatimTextOutput(ns(paste0("summary_", i, "_", j)))
+              ),
+              br(),
+              h4("Coefficient Table"),
+              DTOutput(ns(paste0("fixed_effects_", i, "_", j))),
+              br(),
+              h4("Download Results"),
+              downloadButton(
+                ns(paste0("download_", i, "_", j)),
+                "Download Results (Word)"
+              )
+            )
+          )
+        })
+
+        tabPanel(
+          title = response_name,
+          do.call(tabsetPanel, c(list(id = ns(paste0("strata_tabs_", i))), stratum_tabs))
         )
       })
 
@@ -163,62 +254,146 @@ one_way_anova_server <- function(id, filtered_data) {
 
       responses <- model_info$responses
       model_list <- model_info$models
+      strata_info <- model_info$strata
 
-      for (i in seq_along(responses)) {
-        resp <- responses[i]
-        local({
-          idx <- i
-          response_name <- resp
-          model_obj <- model_list[[response_name]]
+      if (is.null(strata_info)) {
+        for (i in seq_along(responses)) {
+          resp <- responses[i]
+          local({
+            idx <- i
+            response_name <- resp
+            model_obj <- model_list[[response_name]]
 
-          tidy_df <- broom::tidy(model_obj)
-          numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
-          tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+            tidy_df <- broom::tidy(model_obj)
+            numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
+            tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
 
-          output[[paste0("summary_", idx)]] <- renderPrint({
-            summary(model_obj)
-          })
+            output[[paste0("summary_", idx)]] <- renderPrint({
+              summary(model_obj)
+            })
 
-          output[[paste0("fixed_effects_", idx)]] <- renderDT({
-            datatable(
-              tidy_df,
-              options = list(scrollX = TRUE, pageLength = 5),
-              rownames = FALSE
+            output[[paste0("fixed_effects_", idx)]] <- renderDT({
+              datatable(
+                tidy_df,
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+
+            output[[paste0("download_", idx)]] <- downloadHandler(
+              filename = function() {
+                safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
+                safe_resp <- gsub("_+", "_", safe_resp)
+                safe_resp <- gsub("^_|_$", "", safe_resp)
+                if (!nzchar(safe_resp)) {
+                  safe_resp <- paste0("response_", idx)
+                }
+                paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
+              },
+              content = function(file) {
+                tidy_export <- broom::tidy(model_obj)
+                numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
+                tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
+
+                doc <- officer::read_docx()
+                doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
+                doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
+                doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
+                summary_lines <- capture.output(summary(model_obj))
+                for (line in summary_lines) {
+                  doc <- officer::body_add_par(doc, line, style = "Normal")
+                }
+                doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
+                ft <- flextable::flextable(tidy_export)
+                ft <- flextable::autofit(ft)
+                doc <- flextable::body_add_flextable(doc, ft)
+
+                print(doc, target = file)
+              }
             )
           })
+        }
+        return()
+      }
 
-          output[[paste0("download_", idx)]] <- downloadHandler(
-            filename = function() {
-              safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
-              safe_resp <- gsub("_+", "_", safe_resp)
-              safe_resp <- gsub("^_|_$", "", safe_resp)
-              if (!nzchar(safe_resp)) {
-                safe_resp <- paste0("response_", idx)
+      strata_levels <- strata_info$levels
+      for (i in seq_along(responses)) {
+        resp <- responses[i]
+        for (j in seq_along(strata_levels)) {
+          stratum_name <- strata_levels[j]
+          local({
+            idx <- i
+            stratum_idx <- j
+            response_name <- resp
+            stratum_label <- stratum_name
+            model_obj <- model_list[[stratum_label]][[response_name]]
+
+            tidy_df <- broom::tidy(model_obj)
+            numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
+            tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+
+            output[[paste0("summary_", idx, "_", stratum_idx)]] <- renderPrint({
+              summary(model_obj)
+            })
+
+            output[[paste0("fixed_effects_", idx, "_", stratum_idx)]] <- renderDT({
+              datatable(
+                tidy_df,
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+
+            output[[paste0("download_", idx, "_", stratum_idx)]] <- downloadHandler(
+              filename = function() {
+                safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
+                safe_resp <- gsub("_+", "_", safe_resp)
+                safe_resp <- gsub("^_|_$", "", safe_resp)
+                if (!nzchar(safe_resp)) {
+                  safe_resp <- paste0("response_", idx)
+                }
+
+                safe_stratum <- gsub("[^A-Za-z0-9]+", "_", stratum_label)
+                safe_stratum <- gsub("_+", "_", safe_stratum)
+                safe_stratum <- gsub("^_|_$", "", safe_stratum)
+                if (!nzchar(safe_stratum)) {
+                  safe_stratum <- paste0("stratum_", stratum_idx)
+                }
+
+                paste0(
+                  "anova_results_",
+                  safe_resp,
+                  "_stratum_",
+                  safe_stratum,
+                  "_",
+                  Sys.Date(),
+                  ".docx"
+                )
+              },
+              content = function(file) {
+                tidy_export <- broom::tidy(model_obj)
+                numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
+                tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
+
+                doc <- officer::read_docx()
+                doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
+                doc <- officer::body_add_par(doc, paste("Stratum:", stratum_label), style = "heading 2")
+                doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
+                doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
+                summary_lines <- capture.output(summary(model_obj))
+                for (line in summary_lines) {
+                  doc <- officer::body_add_par(doc, line, style = "Normal")
+                }
+                doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
+                ft <- flextable::flextable(tidy_export)
+                ft <- flextable::autofit(ft)
+                doc <- flextable::body_add_flextable(doc, ft)
+
+                print(doc, target = file)
               }
-              paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
-            },
-            content = function(file) {
-              tidy_export <- broom::tidy(model_obj)
-              numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
-              tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
-
-              doc <- officer::read_docx()
-              doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
-              doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
-              doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
-              summary_lines <- capture.output(summary(model_obj))
-              for (line in summary_lines) {
-                doc <- officer::body_add_par(doc, line, style = "Normal")
-              }
-              doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
-              ft <- flextable::flextable(tidy_export)
-              ft <- flextable::autofit(ft)
-              doc <- flextable::body_add_flextable(doc, ft)
-
-              print(doc, target = file)
-            }
-          )
-        })
+            )
+          })
+        }
       }
     })
 

--- a/R/animal_trial_analyzer/module_analysis_two-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_two-way_anova.R
@@ -8,6 +8,7 @@ two_way_anova_ui <- function(id) {
       uiOutput(ns("inputs")),
       uiOutput(ns("level_order_1")),
       uiOutput(ns("level_order_2")),
+      uiOutput(ns("advanced_options")),
       br(),
       actionButton(ns("run"), "Run Two-way ANOVA")
     ),
@@ -35,7 +36,7 @@ two_way_anova_server <- function(id, filtered_data) {
       req(df())
       data <- df()
       cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
-      
+
       tagList(
         # checkbox always present
         checkboxInput(ns("multi_resp"), "Enable multiple response variables", value = FALSE),
@@ -116,6 +117,7 @@ two_way_anova_server <- function(id, filtered_data) {
     # ----------------------------------------------
     models <- eventReactive(input$run, {
       req(df(), input$response, input$factor1, input$factor2, input$order1, input$order2)
+      req(!is.null(input$stratify_var))
       responses <- input$response
       if (!isTRUE(input$multi_resp)) {
         responses <- responses[1]
@@ -131,15 +133,50 @@ two_way_anova_server <- function(id, filtered_data) {
       data[[input$factor1]] <- factor(data[[input$factor1]], levels = input$order1)
       data[[input$factor2]] <- factor(data[[input$factor2]], levels = input$order2)
 
+      strat_var <- input$stratify_var
+
+      if (is.null(strat_var) || identical(strat_var, "None")) {
+        model_list <- list()
+        for (resp in responses) {
+          model_formula <- as.formula(paste(resp, "~", input$factor1, "*", input$factor2))
+          model_list[[resp]] <- lm(model_formula, data = data)
+        }
+
+        return(list(
+          models = model_list,
+          responses = responses,
+          strata = NULL,
+          factors = list(factor1 = input$factor1, factor2 = input$factor2),
+          orders = list(order1 = input$order1, order2 = input$order2)
+        ))
+      }
+
+      strata <- unique(as.character(stats::na.omit(data[[strat_var]])))
+      if (length(strata) == 0) {
+        validate(need(FALSE, "No valid strata found for the selected variable."))
+      }
+
+      if (length(strata) > 10) {
+        validate(need(FALSE, "Stratified analysis supports up to 10 strata."))
+      }
+
       model_list <- list()
-      for (resp in responses) {
-        model_formula <- as.formula(paste(resp, "~", input$factor1, "*", input$factor2))
-        model_list[[resp]] <- lm(model_formula, data = data)
+      for (stratum in strata) {
+        subset_data <- data[data[[strat_var]] == stratum, , drop = FALSE]
+        subset_data[[input$factor1]] <- factor(subset_data[[input$factor1]], levels = input$order1)
+        subset_data[[input$factor2]] <- factor(subset_data[[input$factor2]], levels = input$order2)
+
+        model_list[[stratum]] <- list()
+        for (resp in responses) {
+          model_formula <- as.formula(paste(resp, "~", input$factor1, "*", input$factor2))
+          model_list[[stratum]][[resp]] <- lm(model_formula, data = subset_data)
+        }
       }
 
       list(
         models = model_list,
         responses = responses,
+        strata = list(var = strat_var, levels = strata),
         factors = list(factor1 = input$factor1, factor2 = input$factor2),
         orders = list(order1 = input$order1, order2 = input$order2)
       )
@@ -152,23 +189,60 @@ two_way_anova_server <- function(id, filtered_data) {
       }
 
       responses <- model_info$responses
+      strata_info <- model_info$strata
 
-      tabs <- lapply(seq_along(responses), function(i) {
-        tabPanel(
-          title = responses[i],
-          tags$div(
-            tags$details(
-              open = FALSE,
-              tags$summary(strong("R Output")),
-              verbatimTextOutput(ns(paste0("summary_", i)))
-            ),
-            br(),
-            h4("Coefficient Table"),
-            DTOutput(ns(paste0("fixed_effects_", i))),
-            br(),
-            h4("Download Results"),
-            downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
+      if (is.null(strata_info)) {
+        tabs <- lapply(seq_along(responses), function(i) {
+          tabPanel(
+            title = responses[i],
+            tags$div(
+              tags$details(
+                open = FALSE,
+                tags$summary(strong("R Output")),
+                verbatimTextOutput(ns(paste0("summary_", i)))
+              ),
+              br(),
+              h4("Coefficient Table"),
+              DTOutput(ns(paste0("fixed_effects_", i))),
+              br(),
+              h4("Download Results"),
+              downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
+            )
           )
+        })
+
+        return(do.call(tabsetPanel, c(list(id = ns("results_tabs")), tabs)))
+      }
+
+      strata_levels <- strata_info$levels
+      tabs <- lapply(seq_along(responses), function(i) {
+        response_name <- responses[i]
+        stratum_tabs <- lapply(seq_along(strata_levels), function(j) {
+          stratum_name <- strata_levels[j]
+          tabPanel(
+            title = stratum_name,
+            tags$div(
+              tags$details(
+                open = FALSE,
+                tags$summary(strong("R Output")),
+                verbatimTextOutput(ns(paste0("summary_", i, "_", j)))
+              ),
+              br(),
+              h4("Coefficient Table"),
+              DTOutput(ns(paste0("fixed_effects_", i, "_", j))),
+              br(),
+              h4("Download Results"),
+              downloadButton(
+                ns(paste0("download_", i, "_", j)),
+                "Download Results (Word)"
+              )
+            )
+          )
+        })
+
+        tabPanel(
+          title = response_name,
+          do.call(tabsetPanel, c(list(id = ns(paste0("strata_tabs_", i))), stratum_tabs))
         )
       })
 
@@ -187,63 +261,165 @@ two_way_anova_server <- function(id, filtered_data) {
 
       responses <- model_info$responses
       model_list <- model_info$models
+      strata_info <- model_info$strata
 
-      for (i in seq_along(responses)) {
-        resp <- responses[i]
-        local({
-          idx <- i
-          response_name <- resp
-          model_obj <- model_list[[response_name]]
+      if (is.null(strata_info)) {
+        for (i in seq_along(responses)) {
+          resp <- responses[i]
+          local({
+            idx <- i
+            response_name <- resp
+            model_obj <- model_list[[response_name]]
 
-          tidy_df <- broom::tidy(model_obj)
-          numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
-          tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+            tidy_df <- broom::tidy(model_obj)
+            numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
+            tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
 
-          output[[paste0("summary_", idx)]] <- renderPrint({
-            summary(model_obj)
-          })
+            output[[paste0("summary_", idx)]] <- renderPrint({
+              summary(model_obj)
+            })
 
-          output[[paste0("fixed_effects_", idx)]] <- renderDT({
-            datatable(
-              tidy_df,
-              options = list(scrollX = TRUE, pageLength = 5),
-              rownames = FALSE
+            output[[paste0("fixed_effects_", idx)]] <- renderDT({
+              datatable(
+                tidy_df,
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+
+            output[[paste0("download_", idx)]] <- downloadHandler(
+              filename = function() {
+                safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
+                safe_resp <- gsub("_+", "_", safe_resp)
+                safe_resp <- gsub("^_|_$", "", safe_resp)
+                if (!nzchar(safe_resp)) {
+                  safe_resp <- paste0("response_", idx)
+                }
+                paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
+              },
+              content = function(file) {
+                tidy_export <- broom::tidy(model_obj)
+                numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
+                tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
+
+                doc <- officer::read_docx()
+                doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
+                doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
+                doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
+                summary_lines <- capture.output(summary(model_obj))
+                for (line in summary_lines) {
+                  doc <- officer::body_add_par(doc, line, style = "Normal")
+                }
+                doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
+                ft <- flextable::flextable(tidy_export)
+                ft <- flextable::autofit(ft)
+                doc <- flextable::body_add_flextable(doc, ft)
+
+                print(doc, target = file)
+              }
             )
           })
-
-          output[[paste0("download_", idx)]] <- downloadHandler(
-            filename = function() {
-              safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
-              safe_resp <- gsub("_+", "_", safe_resp)
-              safe_resp <- gsub("^_|_$", "", safe_resp)
-              if (!nzchar(safe_resp)) {
-                safe_resp <- paste0("response_", idx)
-              }
-              paste0("anova_results_", safe_resp, "_", Sys.Date(), ".docx")
-            },
-            content = function(file) {
-              tidy_export <- broom::tidy(model_obj)
-              numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
-              tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
-
-              doc <- officer::read_docx()
-              doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
-              doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
-              doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
-              summary_lines <- capture.output(summary(model_obj))
-              for (line in summary_lines) {
-                doc <- officer::body_add_par(doc, line, style = "Normal")
-              }
-              doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
-              ft <- flextable::flextable(tidy_export)
-              ft <- flextable::autofit(ft)
-              doc <- flextable::body_add_flextable(doc, ft)
-
-              print(doc, target = file)
-            }
-          )
-        })
+        }
+        return()
       }
+
+      strata_levels <- strata_info$levels
+      for (i in seq_along(responses)) {
+        resp <- responses[i]
+        for (j in seq_along(strata_levels)) {
+          stratum_name <- strata_levels[j]
+          local({
+            idx <- i
+            stratum_idx <- j
+            response_name <- resp
+            stratum_label <- stratum_name
+            model_obj <- model_list[[stratum_label]][[response_name]]
+
+            tidy_df <- broom::tidy(model_obj)
+            numeric_cols <- vapply(tidy_df, is.numeric, logical(1))
+            tidy_df[numeric_cols] <- lapply(tidy_df[numeric_cols], function(x) round(x, 4))
+
+            output[[paste0("summary_", idx, "_", stratum_idx)]] <- renderPrint({
+              summary(model_obj)
+            })
+
+            output[[paste0("fixed_effects_", idx, "_", stratum_idx)]] <- renderDT({
+              datatable(
+                tidy_df,
+                options = list(scrollX = TRUE, pageLength = 5),
+                rownames = FALSE
+              )
+            })
+
+            output[[paste0("download_", idx, "_", stratum_idx)]] <- downloadHandler(
+              filename = function() {
+                safe_resp <- gsub("[^A-Za-z0-9]+", "_", response_name)
+                safe_resp <- gsub("_+", "_", safe_resp)
+                safe_resp <- gsub("^_|_$", "", safe_resp)
+                if (!nzchar(safe_resp)) {
+                  safe_resp <- paste0("response_", idx)
+                }
+
+                safe_stratum <- gsub("[^A-Za-z0-9]+", "_", stratum_label)
+                safe_stratum <- gsub("_+", "_", safe_stratum)
+                safe_stratum <- gsub("^_|_$", "", safe_stratum)
+                if (!nzchar(safe_stratum)) {
+                  safe_stratum <- paste0("stratum_", stratum_idx)
+                }
+
+                paste0(
+                  "anova_results_",
+                  safe_resp,
+                  "_stratum_",
+                  safe_stratum,
+                  "_",
+                  Sys.Date(),
+                  ".docx"
+                )
+              },
+              content = function(file) {
+                tidy_export <- broom::tidy(model_obj)
+                numeric_cols_export <- vapply(tidy_export, is.numeric, logical(1))
+                tidy_export[numeric_cols_export] <- lapply(tidy_export[numeric_cols_export], function(x) round(x, 4))
+
+                doc <- officer::read_docx()
+                doc <- officer::body_add_par(doc, paste("ANOVA results for:", response_name), style = "heading 1")
+                doc <- officer::body_add_par(doc, paste("Stratum:", stratum_label), style = "heading 2")
+                doc <- officer::body_add_par(doc, paste("Model formula:", format(formula(model_obj))), style = "heading 2")
+                doc <- officer::body_add_par(doc, "R Output", style = "heading 2")
+                summary_lines <- capture.output(summary(model_obj))
+                for (line in summary_lines) {
+                  doc <- officer::body_add_par(doc, line, style = "Normal")
+                }
+                doc <- officer::body_add_par(doc, "Coefficient Table", style = "heading 2")
+                ft <- flextable::flextable(tidy_export)
+                ft <- flextable::autofit(ft)
+                doc <- flextable::body_add_flextable(doc, ft)
+
+                print(doc, target = file)
+              }
+            )
+          })
+        }
+      }
+    })
+
+    output$advanced_options <- renderUI({
+      req(df())
+      data <- df()
+      cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
+      choices <- c("None", setdiff(unique(cat_cols), "None"))
+
+      tags$details(
+        open = FALSE,
+        tags$summary(strong("Advanced options")),
+        selectInput(
+          ns("stratify_var"),
+          "Stratify analysis by (optional):",
+          choices = choices,
+          selected = "None"
+        )
+      )
     })
 
     return(models)

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -5,26 +5,7 @@ visualize_ui <- function(id) {
   ns <- NS(id)
   tagList(
     h4("4. Visualization"),
-    fluidRow(
-      column(
-        width = 6,
-        numericInput(
-          ns("grid_rows"),
-          label = "Grid rows (optional)",
-          value = 0,        # 0 means auto
-          min = 0, step = 1
-        )
-      ),
-      column(
-        width = 6,
-        numericInput(
-          ns("grid_cols"),
-          label = "Grid columns (optional)",
-          value = 0,        # 0 means auto
-          min = 0, step = 1
-        )
-      )
-    ),
+    uiOutput(ns("layout_controls")),
     fluidRow(
       column(
         width = 6,
@@ -64,45 +45,174 @@ visualize_server <- function(id, filtered_data, model_fit) {
     })
     
     model_info <- reactive({
-      req(model_fit())
       model_fit()
     })
     
-    plot_list <- reactive({
+    compute_layout <- function(n_items, rows_input, cols_input, default_rows = NULL) {
+      if (is.null(n_items) || n_items <= 0) {
+        return(list(nrow = 1, ncol = 1))
+      }
+
+      n_row_input <- suppressWarnings(as.numeric(rows_input))
+      n_col_input <- suppressWarnings(as.numeric(cols_input))
+
+      if (!is.na(n_row_input) && n_row_input > 0) {
+        n_row_final <- n_row_input
+        if (!is.na(n_col_input) && n_col_input > 0) {
+          n_col_final <- max(n_col_input, ceiling(n_items / max(1, n_row_final)))
+        } else {
+          n_col_final <- ceiling(n_items / max(1, n_row_final))
+        }
+      } else if (!is.na(n_col_input) && n_col_input > 0) {
+        n_col_final <- n_col_input
+        n_row_final <- ceiling(n_items / max(1, n_col_final))
+      } else {
+        if (is.null(default_rows)) {
+          n_row_final <- ceiling(sqrt(n_items))
+        } else {
+          n_row_final <- default_rows(n_items)
+        }
+        n_col_final <- ceiling(n_items / max(1, n_row_final))
+      }
+
+      n_row_final <- max(1, as.integer(n_row_final))
+      n_col_final <- max(1, as.integer(n_col_final))
+
+      list(nrow = n_row_final, ncol = n_col_final)
+    }
+
+    output$layout_controls <- renderUI({
+      info <- model_info()
+      has_strata <- !is.null(info) && !is.null(info$strata) && !is.null(info$strata$var)
+      n_responses <- if (!is.null(info) && !is.null(info$responses)) length(info$responses) else 0
+
+      strata_inputs <- if (has_strata) {
+        tagList(
+          h5("Within each response (across strata):"),
+          fluidRow(
+            column(
+              width = 6,
+              numericInput(
+                ns("strata_rows"),
+                "Grid rows (strata)",
+                value = isolate(if (is.null(input$strata_rows)) 0 else input$strata_rows),
+                min = 0,
+                step = 1
+              )
+            ),
+            column(
+              width = 6,
+              numericInput(
+                ns("strata_cols"),
+                "Grid columns (strata)",
+                value = isolate(if (is.null(input$strata_cols)) 0 else input$strata_cols),
+                min = 0,
+                step = 1
+              )
+            )
+          )
+        )
+      } else {
+        NULL
+      }
+
+      response_inputs <- if (!is.null(n_responses) && n_responses > 1) {
+        tagList(
+          h5("Across responses (if multiple):"),
+          fluidRow(
+            column(
+              width = 6,
+              numericInput(
+                ns("resp_rows"),
+                "Grid rows (responses)",
+                value = isolate(if (is.null(input$resp_rows)) 0 else input$resp_rows),
+                min = 0,
+                step = 1
+              )
+            ),
+            column(
+              width = 6,
+              numericInput(
+                ns("resp_cols"),
+                "Grid columns (responses)",
+                value = isolate(if (is.null(input$resp_cols)) 0 else input$resp_cols),
+                min = 0,
+                step = 1
+              )
+            )
+          )
+        )
+      } else {
+        NULL
+      }
+
+      tagList(
+        h4("Layout Controls"),
+        strata_inputs,
+        response_inputs
+      )
+    })
+
+    plot_obj_info <- reactive({
       info <- model_info()
       if (is.null(info) || is.null(info$models) || length(info$models) == 0) {
         return(NULL)
       }
-      
+
       data <- df()
       req(data)
-      
+
       factor1 <- info$factors$factor1
       factor2 <- info$factors$factor2
       order1 <- info$orders$order1
       order2 <- info$orders$order2
-      
+
       if (!is.null(factor1) && !is.null(order1)) {
         data[[factor1]] <- factor(data[[factor1]], levels = order1)
       }
       if (!is.null(factor2) && !is.null(order2)) {
         data[[factor2]] <- factor(data[[factor2]], levels = order2)
       }
-      
+
       responses <- info$responses
-      plot_objects <- list()
-      
-      for (resp in responses) {
+      has_strata <- !is.null(info$strata) && !is.null(info$strata$var)
+      strat_var <- if (has_strata) info$strata$var else NULL
+      strata_levels <- if (has_strata) info$strata$levels else character(0)
+      if (has_strata && (is.null(strata_levels) || length(strata_levels) == 0)) {
+        strata_levels <- unique(as.character(stats::na.omit(data[[strat_var]])))
+      }
+
+      response_plots <- list()
+      max_strata_rows <- 1
+      max_strata_cols <- 1
+
+      default_strata_rows <- function(n) {
+        if (n <= 5) 1 else 2
+      }
+
+      compute_stats <- function(df_subset, resp_name) {
         if (is.null(factor2)) {
-          stats <- data |>
+          df_subset |>
             group_by(.data[[factor1]]) |>
             summarise(
-              mean = mean(.data[[resp]], na.rm = TRUE),
-              se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
+              mean = mean(.data[[resp_name]], na.rm = TRUE),
+              se = sd(.data[[resp_name]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp_name]]))),
               .groups = "drop"
             )
-          
-          p <- ggplot(stats, aes_string(x = factor1, y = "mean")) +
+        } else {
+          df_subset |>
+            group_by(.data[[factor1]], .data[[factor2]]) |>
+            summarise(
+              mean = mean(.data[[resp_name]], na.rm = TRUE),
+              se = sd(.data[[resp_name]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp_name]]))),
+              .groups = "drop"
+            )
+        }
+      }
+
+      build_plot <- function(stats_df, title_text, y_limits) {
+        if (is.null(factor2)) {
+          p <- ggplot(stats_df, aes_string(x = factor1, y = "mean")) +
             geom_line(aes(group = 1), color = "steelblue", linewidth = 1) +
             geom_point(size = 3, color = "steelblue") +
             geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
@@ -112,18 +222,9 @@ visualize_server <- function(id, filtered_data, model_fit) {
             theme(
               panel.grid.minor = element_blank(),
               panel.grid.major.x = element_blank()
-            ) +
-            ggtitle(resp)
-        } else {
-          stats <- data |>
-            group_by(.data[[factor1]], .data[[factor2]]) |>
-            summarise(
-              mean = mean(.data[[resp]], na.rm = TRUE),
-              se = sd(.data[[resp]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp]]))),
-              .groups = "drop"
             )
-          
-          p <- ggplot(stats, aes_string(
+        } else {
+          p <- ggplot(stats_df, aes_string(
             x = factor1,
             y = "mean",
             color = factor2,
@@ -142,50 +243,154 @@ visualize_server <- function(id, filtered_data, model_fit) {
             theme(
               panel.grid.minor = element_blank(),
               panel.grid.major.x = element_blank()
-            ) +
-            ggtitle(resp)
+            )
         }
-        
-        plot_objects[[resp]] <- p
+
+        if (!is.null(y_limits) && all(is.finite(y_limits))) {
+          p <- p + scale_y_continuous(limits = y_limits)
+        }
+
+        p + ggtitle(title_text)
       }
-      
-      plot_objects
-    })
-    
-    # Combine plots and compute grid layout
-    plot_obj <- reactive({
-      plots <- plot_list()
-      if (is.null(plots) || length(plots) == 0) {
+
+      for (resp in responses) {
+        if (has_strata) {
+          stratum_plots <- list()
+          y_values <- c()
+
+          for (stratum in strata_levels) {
+            subset_data <- data[!is.na(data[[strat_var]]) & data[[strat_var]] == stratum, , drop = FALSE]
+            if (nrow(subset_data) == 0) {
+              next
+            }
+
+            stats_df <- compute_stats(subset_data, resp)
+            if (nrow(stats_df) == 0) {
+              next
+            }
+
+            y_values <- c(y_values, stats_df$mean - stats_df$se, stats_df$mean + stats_df$se)
+            stratum_plots[[stratum]] <- stats_df
+          }
+
+          if (length(stratum_plots) == 0) {
+            next
+          }
+
+          y_limits <- range(y_values, na.rm = TRUE)
+          if (!all(is.finite(y_limits))) {
+            y_limits <- NULL
+          }
+
+          strata_plot_list <- lapply(names(stratum_plots), function(stratum_name) {
+            build_plot(stratum_plots[[stratum_name]], stratum_name, y_limits)
+          })
+
+          layout <- compute_layout(
+            length(strata_plot_list),
+            input$strata_rows,
+            input$strata_cols,
+            default_strata_rows
+          )
+
+          max_strata_rows <- max(max_strata_rows, layout$nrow)
+          max_strata_cols <- max(max_strata_cols, layout$ncol)
+
+          combined <- patchwork::wrap_plots(
+            plotlist = strata_plot_list,
+            nrow = layout$nrow,
+            ncol = layout$ncol
+          ) +
+            patchwork::plot_annotation(title = resp)
+
+          response_plots[[resp]] <- combined
+        } else {
+          stats_df <- compute_stats(data, resp)
+          if (nrow(stats_df) == 0) {
+            next
+          }
+
+          y_values <- c(stats_df$mean - stats_df$se, stats_df$mean + stats_df$se)
+          y_limits <- range(y_values, na.rm = TRUE)
+          if (!all(is.finite(y_limits))) {
+            y_limits <- NULL
+          }
+
+          response_plots[[resp]] <- build_plot(stats_df, resp, y_limits)
+          max_strata_rows <- max(max_strata_rows, 1)
+          max_strata_cols <- max(max_strata_cols, 1)
+        }
+      }
+
+      if (length(response_plots) == 0) {
         return(NULL)
       }
-      
-      n <- length(plots)
-      n_row <- suppressWarnings(as.numeric(input$grid_rows))
-      n_col <- suppressWarnings(as.numeric(input$grid_cols))
-      
-      if (is.na(n_row) || n_row < 1) n_row <- ceiling(sqrt(n))
-      if (is.na(n_col) || n_col < 1) n_col <- ceiling(n / n_row)
-      
-      patchwork::wrap_plots(plotlist = plots, nrow = n_row, ncol = n_col)
+
+      resp_layout <- compute_layout(
+        length(response_plots),
+        if (!is.null(input$resp_rows)) input$resp_rows else 0,
+        if (!is.null(input$resp_cols)) input$resp_cols else 0
+      )
+
+      final_plot <- if (length(response_plots) == 1) {
+        response_plots[[1]]
+      } else {
+        patchwork::wrap_plots(
+          plotlist = response_plots,
+          nrow = resp_layout$nrow,
+          ncol = resp_layout$ncol
+        )
+      }
+
+      list(
+        plot = final_plot,
+        layout = list(
+          strata = list(rows = max_strata_rows, cols = max_strata_cols),
+          responses = resp_layout
+        ),
+        has_strata = has_strata,
+        n_responses = length(response_plots)
+      )
+    })
+
+    plot_obj <- reactive({
+      info <- plot_obj_info()
+      if (is.null(info)) {
+        return(NULL)
+      }
+      info$plot
     })
     
     # ---- Dynamic sizing logic (pixels) ----
     plot_size <- reactive({
-      n <- length(plot_list())
+      info <- plot_obj_info()
       w_sub <- input$subplot_width
       h_sub <- input$subplot_height
-      
-      if (is.null(n) || n == 0) return(list(w = w_sub, h = h_sub))
-      if (n == 1) return(list(w = w_sub, h = h_sub))
-      
-      n_row <- suppressWarnings(as.numeric(input$grid_rows))
-      n_col <- suppressWarnings(as.numeric(input$grid_cols))
-      if (is.na(n_row) || n_row < 1) n_row <- ceiling(sqrt(n))
-      if (is.na(n_col) || n_col < 1) n_col <- ceiling(n / n_row)
-      
+
+      if (is.null(w_sub) || is.na(w_sub)) {
+        w_sub <- 300
+      }
+      if (is.null(h_sub) || is.na(h_sub)) {
+        h_sub <- 200
+      }
+
+      if (is.null(info)) {
+        return(list(w = w_sub, h = h_sub))
+      }
+
+      strata_cols <- info$layout$strata$cols
+      strata_rows <- info$layout$strata$rows
+      resp_cols <- info$layout$responses$ncol
+      resp_rows <- info$layout$responses$nrow
+
+      if (is.null(strata_cols) || strata_cols < 1) strata_cols <- 1
+      if (is.null(strata_rows) || strata_rows < 1) strata_rows <- 1
+      if (is.null(resp_cols) || resp_cols < 1) resp_cols <- 1
+      if (is.null(resp_rows) || resp_rows < 1) resp_rows <- 1
+
       list(
-        w = w_sub * n_col,
-        h = h_sub * n_row
+        w = w_sub * strata_cols * resp_cols,
+        h = h_sub * strata_rows * resp_rows
       )
     })
     


### PR DESCRIPTION
## Summary
- add advanced stratification controls to one-way and two-way ANOVA modules and return nested model structures
- render stratified ANOVA results with response/stratum tabsets and dedicated Word exports
- upgrade visualization controls and plotting logic to handle strata-aware subplots and dual grid layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0dfc8059c832bb9691edb5f604536