### PR TITLE
Refactor animal trial analyzer modules for standalone layouts

### DIFF
--- a/R/animal_trial_analyzer/module_analysis.R
+++ b/R/animal_trial_analyzer/module_analysis.R
@@ -7,16 +7,32 @@ source("R/animal_trial_analyzer/module_analysis_utils.R")
 
 analysis_ui <- function(id) {
   ns <- NS(id)
-  list(
-    heading = h4("3. Statistical Analysis"),
-    type_selector = selectInput(
-      ns("analysis_type"),
-      "Select analysis type:",
-      choices = c("One-way ANOVA", "Two-way ANOVA"),  # more will be added here later
-      selected = "One-way ANOVA"
+  sidebarLayout(
+    sidebarPanel(
+      width = 4,
+      h4("Step 3 — Analyze Results"),
+      p("Choose the statistical approach that fits your trial design, then inspect the summaries on the right."),
+      hr(),
+      selectInput(
+        ns("analysis_type"),
+        "Select analysis type:",
+        choices = c("One-way ANOVA", "Two-way ANOVA"),
+        selected = "One-way ANOVA"
+      ),
+      hr(),
+      uiOutput(ns("config_panel")),
+      hr(),
+      div(
+        class = "d-flex justify-content-between gap-2",
+        actionButton(ns("back_filter"), "← Back"),
+        actionButton(ns("go_visualize"), "Continue →", class = "btn-primary")
+      )
     ),
-    config_panel = uiOutput(ns("config_panel")),
-    results_panel = uiOutput(ns("results_panel"))
+    mainPanel(
+      width = 8,
+      h4("Analysis Results"),
+      uiOutput(ns("results_panel"))
+    )
   )
 }
 

--- a/R/animal_trial_analyzer/module_filter.R
+++ b/R/animal_trial_analyzer/module_filter.R
@@ -3,12 +3,27 @@
 # ===============================================================
 filter_ui <- function(id) {
   ns <- NS(id)
-  tagList(
-    h4("2. Filter Data"),
-    uiOutput(ns("column_selector")),
-    uiOutput(ns("filter_widgets")),
-    br(),
-    DTOutput(ns("filtered_preview"))
+  sidebarLayout(
+    sidebarPanel(
+      width = 4,
+      h4("Step 2 — Filter Records"),
+      p("Pick the columns to focus on and adjust the filters to refine the dataset for analysis."),
+      hr(),
+      uiOutput(ns("column_selector")),
+      hr(),
+      uiOutput(ns("filter_widgets")),
+      hr(),
+      div(
+        class = "d-flex justify-content-between gap-2",
+        actionButton(ns("back_upload"), "← Back"),
+        actionButton(ns("go_analysis"), "Continue →", class = "btn-primary")
+      )
+    ),
+    mainPanel(
+      width = 8,
+      h4("Filtered Data Preview"),
+      DTOutput(ns("filtered_preview"))
+    )
   )
 }
 

--- a/R/animal_trial_analyzer/module_upload.R
+++ b/R/animal_trial_analyzer/module_upload.R
@@ -4,13 +4,31 @@
 
 upload_ui <- function(id) {
   ns <- NS(id)
-  tagList(
-    h4("1. Upload Data (long or flat-wide format)"),
-    fileInput(ns("file"), "Upload Excel file (.xlsx / .xls / .xlsm)", accept = c(".xlsx", ".xls", ".xlsm")),
-    uiOutput(ns("sheet_selector")),     # <- will always render something
-    br(),
-    verbatimTextOutput(ns("validation_msg")),  # format checks + debug text
-    DTOutput(ns("preview"))
+  sidebarLayout(
+    sidebarPanel(
+      width = 4,
+      h4("Step 1 — Upload Data"),
+      p("Upload your Excel file in long format, choose the worksheet, and follow the guidance before proceeding."),
+      hr(),
+      fileInput(
+        ns("file"),
+        "Upload Excel file (.xlsx / .xls / .xlsm)",
+        accept = c(".xlsx", ".xls", ".xlsm")
+      ),
+      uiOutput(ns("sheet_selector")),
+      hr(),
+      div(
+        class = "d-flex justify-content-end",
+        actionButton(ns("go_filter"), "Continue →", class = "btn-primary")
+      )
+    ),
+    mainPanel(
+      width = 8,
+      h4("Data Preview"),
+      verbatimTextOutput(ns("validation_msg")),
+      hr(),
+      DTOutput(ns("preview"))
+    )
   )
 }
 

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -3,35 +3,52 @@
 # ===============================================================
 visualize_ui <- function(id) {
   ns <- NS(id)
-  tagList(
-    h4("4. Visualization"),
-    uiOutput(ns("layout_controls")),
-    fluidRow(
-      column(
-        width = 6,
-        numericInput(
-          ns("subplot_width"),
-          label = "Subplot width (px)",
-          value = 300,
-          min = 200,
-          max = 1200,
-          step = 50
+  sidebarLayout(
+    sidebarPanel(
+      width = 4,
+      h4("Step 4 — Visualize Outcomes"),
+      p("Tweak the layout of the mean ± SE plots, download the figure, and wrap up your workflow."),
+      hr(),
+      uiOutput(ns("layout_controls")),
+      hr(),
+      fluidRow(
+        column(
+          width = 6,
+          numericInput(
+            ns("subplot_width"),
+            label = "Subplot width (px)",
+            value = 300,
+            min = 200,
+            max = 1200,
+            step = 50
+          )
+        ),
+        column(
+          width = 6,
+          numericInput(
+            ns("subplot_height"),
+            label = "Subplot height (px)",
+            value = 200,
+            min = 200,
+            max = 1200,
+            step = 50
+          )
         )
       ),
-      column(
-        width = 6,
-        numericInput(
-          ns("subplot_height"),
-          label = "Subplot height (px)",
-          value = 200,
-          min = 200,
-          max = 1200,
-          step = 50
-        )
+      hr(),
+      downloadButton(ns("download_plot"), "Download PNG (300 dpi)"),
+      hr(),
+      div(
+        class = "d-flex justify-content-between gap-2",
+        actionButton(ns("back_analysis"), "← Back"),
+        actionButton(ns("finish"), "Finish", class = "btn-success")
       )
     ),
-    downloadButton(ns("download_plot"), "Download PNG (300 dpi)"),
-    plotOutput(ns("mean_se_plot"))
+    mainPanel(
+      width = 8,
+      h4("Mean ± SE Plot"),
+      plotOutput(ns("mean_se_plot"))
+    )
   )
 }
 

--- a/animal_trial_analyzer_module.R
+++ b/animal_trial_analyzer_module.R
@@ -13,120 +13,10 @@ animal_trial_app_ui <- function(id) {
     h3("Animal Trial Analyzer"),
     tabsetPanel(
       id = ns("main_tabs"),
-      tabPanel(
-        title = "1️⃣ Upload",
-        {
-          upload_components <- upload_ui(ns("upload"))
-          sidebarLayout(
-            sidebarPanel(
-              width = 4,
-              h4("Step 1 — Upload Data"),
-              p("Upload your Excel file in long format, choose the worksheet, and follow the guidance before proceeding."),
-              hr(),
-              upload_components[[2]],
-              upload_components[[3]],
-              hr(),
-              div(
-                class = "d-flex justify-content-end",
-                actionButton(ns("go_filter"), "Continue →", class = "btn-primary")
-              )
-            ),
-            mainPanel(
-              width = 8,
-              h4("Data Preview"),
-              upload_components[[5]],
-              hr(),
-              upload_components[[6]]
-            )
-          )
-        }
-      ),
-      tabPanel(
-        title = "2️⃣ Filter",
-        {
-          filter_components <- filter_ui(ns("filter"))
-          sidebarLayout(
-            sidebarPanel(
-              width = 4,
-              h4("Step 2 — Filter Records"),
-              p("Pick the columns to focus on and adjust the filters to refine the dataset for analysis."),
-              hr(),
-              filter_components[[2]],
-              hr(),
-              filter_components[[3]],
-              hr(),
-              div(
-                class = "d-flex justify-content-between gap-2",
-                actionButton(ns("back_upload"), "← Back"),
-                actionButton(ns("go_analysis"), "Continue →", class = "btn-primary")
-              )
-            ),
-            mainPanel(
-              width = 8,
-              h4("Filtered Data Preview"),
-              filter_components[[5]]
-            )
-          )
-        }
-      ),
-      tabPanel(
-        title = "3️⃣ Analyze",
-        {
-          analysis_components <- analysis_ui(ns("analysis"))
-          sidebarLayout(
-            sidebarPanel(
-              width = 4,
-              h4("Step 3 — Analyze Results"),
-              p("Choose the statistical approach that fits your trial design, then inspect the summaries on the right."),
-              hr(),
-              analysis_components$type_selector,
-              hr(),
-              analysis_components$config_panel,
-              hr(),
-              div(
-                class = "d-flex justify-content-between gap-2",
-                actionButton(ns("back_filter"), "← Back"),
-                actionButton(ns("go_visualize"), "Continue →", class = "btn-primary")
-              )
-            ),
-            mainPanel(
-              width = 8,
-              h4("Analysis Results"),
-              analysis_components$results_panel
-            )
-          )
-        }
-      ),
-      tabPanel(
-        title = "4️⃣ Visualize",
-        {
-          visualize_components <- visualize_ui(ns("visualize"))
-          sidebarLayout(
-            sidebarPanel(
-              width = 4,
-              h4("Step 4 — Visualize Outcomes"),
-              p("Tweak the layout of the mean ± SE plots, download the figure, and wrap up your workflow."),
-              hr(),
-              visualize_components[[2]],
-              hr(),
-              visualize_components[[3]],
-              hr(),
-              visualize_components[[4]],
-              hr(),
-              div(
-                class = "d-flex justify-content-between gap-2",
-                actionButton(ns("back_analysis"), "← Back"),
-                actionButton(ns("finish"), "Finish", class = "btn-success")
-              )
-            ),
-            mainPanel(
-              width = 8,
-              h4("Mean ± SE Plot"),
-              visualize_components[[5]]
-            )
-          )
-        }
-      )
+      tabPanel("1️⃣ Upload", upload_ui(ns("upload"))),
+      tabPanel("2️⃣ Filter", filter_ui(ns("filter"))),
+      tabPanel("3️⃣ Analyze", analysis_ui(ns("analysis"))),
+      tabPanel("4️⃣ Visualize", visualize_ui(ns("visualize")))
     )
   )
 }
@@ -140,29 +30,29 @@ animal_trial_app_server <- function(id) {
     analyzed  <- analysis_server("analysis", filtered)
     visualize_server("visualize", filtered, analyzed)
 
-    observeEvent(input$go_filter, {
+    observeEvent(input[["upload-go_filter"]], {
       updateTabsetPanel(session, "main_tabs", selected = "2️⃣ Filter")
-    })
+    }, ignoreNULL = TRUE)
 
-    observeEvent(input$back_upload, {
+    observeEvent(input[["filter-back_upload"]], {
       updateTabsetPanel(session, "main_tabs", selected = "1️⃣ Upload")
-    })
+    }, ignoreNULL = TRUE)
 
-    observeEvent(input$go_analysis, {
+    observeEvent(input[["filter-go_analysis"]], {
       updateTabsetPanel(session, "main_tabs", selected = "3️⃣ Analyze")
-    })
+    }, ignoreNULL = TRUE)
 
-    observeEvent(input$back_filter, {
+    observeEvent(input[["analysis-back_filter"]], {
       updateTabsetPanel(session, "main_tabs", selected = "2️⃣ Filter")
-    })
+    }, ignoreNULL = TRUE)
 
-    observeEvent(input$go_visualize, {
+    observeEvent(input[["analysis-go_visualize"]], {
       updateTabsetPanel(session, "main_tabs", selected = "4️⃣ Visualize")
-    })
+    }, ignoreNULL = TRUE)
 
-    observeEvent(input$back_analysis, {
+    observeEvent(input[["visualize-back_analysis"]], {
       updateTabsetPanel(session, "main_tabs", selected = "3️⃣ Analyze")
-    })
+    }, ignoreNULL = TRUE)
 
     analysis_notified <- reactiveVal(FALSE)
 
@@ -179,8 +69,8 @@ animal_trial_app_server <- function(id) {
       analysis_notified(TRUE)
     }, ignoreNULL = TRUE)
 
-    observeEvent(input$finish, {
+    observeEvent(input[["visualize-finish"]], {
       showModal(modalDialog("🎉 All done!", easyClose = TRUE))
-    })
+    }, ignoreNULL = TRUE)
   })
 }


### PR DESCRIPTION
## Summary
- rewrite each animal trial analyzer step module to render its own sidebar layout with navigation controls
- simplify the coordinator UI by embedding the modules directly into tab panels
- update tab navigation observers to use the modules' namespaced button IDs while preserving notifications and finish modal

## Testing
- ⚠️ `R -q -e "source('animal_trial_analyzer_module.R'); cat('modules ok\n')"` *(fails: R executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f29add1824832b8c9036d2b5f1dbc5