### PR TITLE
Refine analysis helpers and trim dependencies

### DIFF
--- a/R/animal_trial_analyzer/module_analysis_two-way_anova.R
+++ b/R/animal_trial_analyzer/module_analysis_two-way_anova.R
@@ -29,127 +29,6 @@ two_way_anova_server <- function(id, filtered_data) {
       filtered_data()
     })
 
-    format_p_value <- function(p_values) {
-      vapply(
-        p_values,
-        function(p) {
-          if (is.na(p)) {
-            return(NA_character_)
-          }
-          if (p < 0.001) {
-            "<0.001"
-          } else {
-            sprintf("%.2f", round(p, 2))
-          }
-        },
-        character(1)
-      )
-    }
-
-    add_significance_marker <- function(formatted_p, raw_p) {
-      mapply(
-        function(fp, rp) {
-          if (is.na(rp)) {
-            return(fp)
-          }
-          if (rp < 0.05) {
-            paste0(fp, "*")
-          } else {
-            fp
-          }
-        },
-        formatted_p,
-        raw_p,
-        USE.NAMES = FALSE
-      )
-    }
-
-    prepare_anova_outputs <- function(model_obj, factor_names) {
-      old_contrasts <- options("contrasts")
-      on.exit(options(old_contrasts), add = TRUE)
-      options(contrasts = c("contr.sum", "contr.poly"))
-
-      anova_obj <- car::Anova(model_obj, type = 3)
-      anova_df <- as.data.frame(anova_obj)
-      anova_df$Effect <- rownames(anova_df)
-      rownames(anova_df) <- NULL
-      anova_df <- anova_df[, c("Effect", setdiff(names(anova_df), "Effect"))]
-
-      p_col <- grep("^Pr", names(anova_df), value = TRUE)
-      p_col <- if (length(p_col) > 0) p_col[1] else NULL
-      raw_p <- if (!is.null(p_col)) anova_df[[p_col]] else rep(NA_real_, nrow(anova_df))
-
-      for (col in names(anova_df)) {
-        if (is.numeric(anova_df[[col]])) {
-          anova_df[[col]] <- round(anova_df[[col]], 2)
-        }
-      }
-
-      anova_significant <- !is.na(raw_p) & raw_p < 0.05
-      if (!is.null(p_col)) {
-        formatted_p <- format_p_value(raw_p)
-        anova_df[[p_col]] <- add_significance_marker(formatted_p, raw_p)
-        names(anova_df)[names(anova_df) == p_col] <- "p.value"
-      } else {
-        anova_df$p.value <- NA_character_
-      }
-
-      factor_names <- unique(factor_names[!is.na(factor_names) & nzchar(factor_names)])
-      posthoc_details <- list()
-      posthoc_combined <- NULL
-      posthoc_significant <- numeric(0)
-
-      for (factor_nm in factor_names) {
-        if (!factor_nm %in% names(model_obj$model)) {
-          next
-        }
-
-        res <- tryCatch({
-          emm <- emmeans::emmeans(model_obj, specs = factor_nm)
-          contrasts <- emmeans::contrast(emm, method = "pairwise", adjust = "tukey")
-          as.data.frame(summary(contrasts))
-        }, error = function(e) {
-          list(error = e$message)
-        })
-
-        if (is.data.frame(res)) {
-          res$Factor <- factor_nm
-          posthoc_details[[factor_nm]] <- list(table = res, error = NULL)
-          posthoc_combined <- rbind(posthoc_combined, res)
-        } else {
-          posthoc_details[[factor_nm]] <- list(table = NULL, error = res$error)
-        }
-      }
-
-      if (!is.null(posthoc_combined)) {
-        posthoc_combined <- posthoc_combined[, c("Factor", setdiff(names(posthoc_combined), "Factor"))]
-        numeric_cols <- names(posthoc_combined)[sapply(posthoc_combined, is.numeric)]
-        if (length(numeric_cols) > 0) {
-          for (col in numeric_cols) {
-            posthoc_combined[[col]] <- round(posthoc_combined[[col]], 2)
-          }
-        }
-
-        if ("p.value" %in% names(posthoc_combined)) {
-          raw_posthoc_p <- posthoc_combined$p.value
-          posthoc_significant <- !is.na(raw_posthoc_p) & raw_posthoc_p < 0.05
-          formatted_posthoc_p <- format_p_value(raw_posthoc_p)
-          posthoc_combined$p.value <- add_significance_marker(formatted_posthoc_p, raw_posthoc_p)
-        } else {
-          posthoc_significant <- rep(FALSE, nrow(posthoc_combined))
-        }
-      }
-
-      list(
-        anova_object = anova_obj,
-        anova_table = anova_df,
-        anova_significant = anova_significant,
-        posthoc_details = posthoc_details,
-        posthoc_table = posthoc_combined,
-        posthoc_significant = posthoc_significant
-      )
-    }
-
     # ----------------------------------------------
     # Dynamic input selectors for response and factors
     # ----------------------------------------------
@@ -329,7 +208,7 @@ two_way_anova_server <- function(id, filtered_data) {
               verbatimTextOutput(ns(paste0("summary_", i))),
               br(),
               h4("Coefficient Table"),
-              DTOutput(ns(paste0("fixed_effects_", i))),
+              DT::DTOutput(ns(paste0("fixed_effects_", i))),
               br(),
               h4("Download Results"),
               downloadButton(ns(paste0("download_", i)), "Download Results (Word)")
@@ -355,7 +234,7 @@ two_way_anova_server <- function(id, filtered_data) {
               ),
               br(),
               h4("Coefficient Table"),
-              DTOutput(ns(paste0("fixed_effects_", i, "_", j))),
+              DT::DTOutput(ns(paste0("fixed_effects_", i, "_", j))),
               br(),
               h4("Download Results"),
               downloadButton(
@@ -432,8 +311,8 @@ two_way_anova_server <- function(id, filtered_data) {
               }
             })
 
-            output[[paste0("fixed_effects_", idx)]] <- renderDT({
-              datatable(
+            output[[paste0("fixed_effects_", idx)]] <- DT::renderDT({
+              DT::datatable(
                 tidy_df,
                 options = list(scrollX = TRUE, pageLength = 5),
                 rownames = FALSE
@@ -535,8 +414,8 @@ two_way_anova_server <- function(id, filtered_data) {
               }
             })
 
-            output[[paste0("fixed_effects_", idx, "_", stratum_idx)]] <- renderDT({
-              datatable(
+            output[[paste0("fixed_effects_", idx, "_", stratum_idx)]] <- DT::renderDT({
+              DT::datatable(
                 tidy_df,
                 options = list(scrollX = TRUE, pageLength = 5),
                 rownames = FALSE

--- a/R/animal_trial_analyzer/module_analysis_utils.R
+++ b/R/animal_trial_analyzer/module_analysis_utils.R
@@ -7,3 +7,121 @@ validate_numeric_and_factor <- function(data) {
   cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
   list(numeric = num_cols, categorical = cat_cols)
 }
+
+format_p_values <- function(p_values, digits = 2, threshold = 0.001) {
+  vapply(
+    p_values,
+    function(p) {
+      if (is.na(p)) {
+        return(NA_character_)
+      }
+      if (p < threshold) {
+        paste0("<", format(threshold, trim = TRUE))
+      } else {
+        sprintf(paste0("%.", digits, "f"), round(p, digits))
+      }
+    },
+    character(1)
+  )
+}
+
+add_significance_markers <- function(formatted_p, raw_p, sig_level = 0.05, symbol = "*") {
+  mapply(
+    function(fp, rp) {
+      if (is.na(rp) || is.na(fp)) {
+        return(fp)
+      }
+      if (rp < sig_level) {
+        paste0(fp, symbol)
+      } else {
+        fp
+      }
+    },
+    formatted_p,
+    raw_p,
+    USE.NAMES = FALSE
+  )
+}
+
+prepare_anova_outputs <- function(model_obj, factor_names, sig_level = 0.05, digits = 2) {
+  old_contrasts <- options("contrasts")
+  on.exit(options(old_contrasts), add = TRUE)
+  options(contrasts = c("contr.sum", "contr.poly"))
+
+  anova_obj <- car::Anova(model_obj, type = 3)
+  anova_df <- as.data.frame(anova_obj)
+  anova_df$Effect <- rownames(anova_df)
+  rownames(anova_df) <- NULL
+  anova_df <- anova_df[, c("Effect", setdiff(names(anova_df), "Effect"))]
+
+  p_col <- grep("^Pr", names(anova_df), value = TRUE)
+  p_col <- if (length(p_col) > 0) p_col[1] else NULL
+  raw_p <- if (!is.null(p_col)) anova_df[[p_col]] else rep(NA_real_, nrow(anova_df))
+
+  numeric_cols <- vapply(anova_df, is.numeric, logical(1))
+  if (any(numeric_cols)) {
+    anova_df[numeric_cols] <- lapply(anova_df[numeric_cols], round, digits = digits)
+  }
+
+  anova_significant <- !is.na(raw_p) & raw_p < sig_level
+  if (!is.null(p_col)) {
+    formatted_p <- format_p_values(raw_p, digits = digits)
+    anova_df[[p_col]] <- add_significance_markers(formatted_p, raw_p, sig_level = sig_level)
+    names(anova_df)[names(anova_df) == p_col] <- "p.value"
+  } else {
+    anova_df$p.value <- NA_character_
+  }
+
+  factor_names <- unique(factor_names[!is.na(factor_names) & nzchar(factor_names)])
+  posthoc_details <- list()
+  posthoc_combined <- NULL
+  posthoc_significant <- logical()
+
+  for (factor_nm in factor_names) {
+    if (!factor_nm %in% names(model_obj$model)) {
+      next
+    }
+
+    res <- tryCatch({
+      emm <- emmeans::emmeans(model_obj, specs = factor_nm)
+      contrasts <- emmeans::contrast(emm, method = "pairwise", adjust = "tukey")
+      as.data.frame(summary(contrasts))
+    }, error = function(e) {
+      list(error = e$message)
+    })
+
+    if (is.data.frame(res)) {
+      res$Factor <- factor_nm
+      posthoc_details[[factor_nm]] <- list(table = res, error = NULL)
+      posthoc_combined <- rbind(posthoc_combined, res)
+    } else {
+      posthoc_details[[factor_nm]] <- list(table = NULL, error = res$error)
+    }
+  }
+
+  if (!is.null(posthoc_combined)) {
+    posthoc_combined <- posthoc_combined[, c("Factor", setdiff(names(posthoc_combined), "Factor"))]
+    numeric_cols <- vapply(posthoc_combined, is.numeric, logical(1))
+    if (any(numeric_cols)) {
+      posthoc_combined[numeric_cols] <- lapply(posthoc_combined[numeric_cols], round, digits = digits)
+    }
+
+    if ("p.value" %in% names(posthoc_combined)) {
+      raw_posthoc_p <- posthoc_combined$p.value
+      posthoc_significant <- !is.na(raw_posthoc_p) & raw_posthoc_p < sig_level
+      formatted_posthoc_p <- format_p_values(raw_posthoc_p, digits = digits)
+      posthoc_combined$p.value <- add_significance_markers(formatted_posthoc_p, raw_posthoc_p, sig_level = sig_level)
+    } else {
+      posthoc_significant <- rep(FALSE, nrow(posthoc_combined))
+    }
+  }
+
+  list(
+    anova_object = anova_obj,
+    anova_table = anova_df,
+    anova_significant = anova_significant,
+    posthoc_details = posthoc_details,
+    posthoc_table = posthoc_combined,
+    posthoc_significant = posthoc_significant
+  )
+}

--- a/R/animal_trial_analyzer/module_filter.R
+++ b/R/animal_trial_analyzer/module_filter.R
@@ -22,7 +22,7 @@ filter_ui <- function(id) {
     mainPanel(
       width = 8,
       h4("Filtered Data Preview"),
-      DTOutput(ns("filtered_preview"))
+      DT::DTOutput(ns("filtered_preview"))
     )
   )
 }
@@ -140,9 +140,9 @@ filter_server <- function(id, uploaded_data) {
     
     
     # --- 4. Preview
-    output$filtered_preview <- renderDT({
+    output$filtered_preview <- DT::renderDT({
       req(filtered_df())
-      datatable(filtered_df(),
+      DT::datatable(filtered_df(),
                 options = list(scrollX = TRUE, pageLength = 5))
     })
     

--- a/R/animal_trial_analyzer/module_upload.R
+++ b/R/animal_trial_analyzer/module_upload.R
@@ -36,7 +36,7 @@ upload_ui <- function(id) {
       h4("Data Preview"),
       verbatimTextOutput(ns("validation_msg")),
       hr(),
-      DTOutput(ns("preview"))
+      DT::DTOutput(ns("preview"))
     )
   )
 }
@@ -57,7 +57,7 @@ upload_server <- function(id) {
       
       fname <- input$file$name
       fpath <- input$file$datapath
-      ext   <- tolower(file_ext(fname))
+      ext   <- tolower(tools::file_ext(fname))
       
       # Show immediate debug info
       output$validation_msg <- renderText({
@@ -81,7 +81,7 @@ upload_server <- function(id) {
         return()
       }
       
-      sheets <- tryCatch(excel_sheets(fpath), error = function(e) e)
+      sheets <- tryCatch(readxl::excel_sheets(fpath), error = function(e) e)
       
       if (inherits(sheets, "error")) {
         output$sheet_selector <- renderUI(
@@ -109,7 +109,7 @@ upload_server <- function(id) {
       req(input$file, input$sheet)
       
       tmp <- tryCatch(
-        read_excel(input$file$datapath, sheet = input$sheet),
+        readxl::read_excel(input$file$datapath, sheet = input$sheet),
         error = function(e) e
       )
       if (inherits(tmp, "error")) {
@@ -117,7 +117,7 @@ upload_server <- function(id) {
         output$validation_msg <- renderText(
           paste("❌ Error loading sheet:", conditionMessage(tmp))
         )
-        output$preview <- renderDT(NULL)
+        output$preview <- DT::renderDT(NULL)
         return()
       }
       
@@ -152,7 +152,7 @@ upload_server <- function(id) {
       
       df(tmp)
       
-      output$preview <- renderDT(
+      output$preview <- DT::renderDT(
         tmp,
         options = list(scrollX = TRUE, pageLength = 5)
       )

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -320,18 +320,20 @@ visualize_server <- function(id, filtered_data, model_fit) {
       compute_stats <- function(df_subset, resp_name) {
         if (is.null(factor2)) {
           df_subset |>
-            group_by(.data[[factor1]]) |>
-            summarise(
-              mean = mean(.data[[resp_name]], na.rm = TRUE),
-              se = sd(.data[[resp_name]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp_name]]))),
+            dplyr::group_by(rlang::.data[[factor1]]) |>
+            dplyr::summarise(
+              mean = mean(rlang::.data[[resp_name]], na.rm = TRUE),
+              se = stats::sd(rlang::.data[[resp_name]], na.rm = TRUE) /
+                sqrt(sum(!is.na(rlang::.data[[resp_name]]))),
               .groups = "drop"
             )
         } else {
           df_subset |>
-            group_by(.data[[factor1]], .data[[factor2]]) |>
-            summarise(
-              mean = mean(.data[[resp_name]], na.rm = TRUE),
-              se = sd(.data[[resp_name]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp_name]]))),
+            dplyr::group_by(rlang::.data[[factor1]], rlang::.data[[factor2]]) |>
+            dplyr::summarise(
+              mean = mean(rlang::.data[[resp_name]], na.rm = TRUE),
+              se = stats::sd(rlang::.data[[resp_name]], na.rm = TRUE) /
+                sqrt(sum(!is.na(rlang::.data[[resp_name]]))),
               .groups = "drop"
             )
         }

--- a/app.R
+++ b/app.R
@@ -1,16 +1,6 @@
 library(shiny)
 library(bslib)
-library(readxl)
-library(DT)
-library(tools)
-library(broom)
-library(janitor)
-library(data.table)
 library(ggplot2)
-library(dplyr)
-library(patchwork)
-library(officer)
-library(flextable)
 
 options(shiny.autoreload = TRUE)
 

--- a/sankey_module.R
+++ b/sankey_module.R
@@ -4,10 +4,6 @@
 #' Sankey diagram. The module supports multiple tabular formats and offers an
 #' interactive data preview using DT.
 
-library(DT)
-library(readxl)
-library(data.table)
-
 # --- Demo dataset ---
 demo_sankey_data <- tibble::tribble(
   ~Species,  ~Condition,  ~Outcome,
@@ -53,7 +49,7 @@ sankey_app_ui <- function(id) {
     ),
     mainPanel(
       h4("Preview of Your Data"),
-      DTOutput(ns("preview")),
+      DT::DTOutput(ns("preview")),
       hr(),
       h4("Sankey Plot"),
       p("Each arrow shows how many items flow between categories. The width of a link corresponds to its value."),
@@ -92,9 +88,9 @@ sankey_app_server <- function(id) {
     })
     
     # Data preview
-    output$preview <- renderDT({
+    output$preview <- DT::renderDT({
       req(data())
-      datatable(
+      DT::datatable(
         data(),
         options = list(pageLength = 10, scrollX = TRUE),
         rownames = FALSE
@@ -135,7 +131,7 @@ sankey_app_server <- function(id) {
         col1 <- input$cols[i]
         col2 <- input$cols[i + 1]
         tmp <- df |>
-          dplyr::count(.data[[col1]], .data[[col2]], name = "value") |>
+          dplyr::count(rlang::.data[[col1]], rlang::.data[[col2]], name = "value") |>
           dplyr::rename(source = 1, target = 2) |>
           dplyr::mutate(dplyr::across(c(source, target), as.character))
         edges_list[[i]] <- tmp


### PR DESCRIPTION
## Summary
- consolidate p-value formatting and ANOVA summarisation helpers so both analysis modules share the same implementation
- namespace DT and tidyverse calls across the Shiny modules to remove redundant library side effects
- drop unused top-level library imports now that modules manage their own dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f29e60ba04832b8804b8f654496aef