### PR TITLE
Adjust visualization defaults by analysis type

### DIFF
--- a/R/animal_trial_analyzer/module_analysis_anova_helpers.R
+++ b/R/animal_trial_analyzer/module_analysis_anova_helpers.R
@@ -80,6 +80,7 @@ prepare_stratified_models <- function(df, responses, strat_var, factor1, factor2
       model_list[[resp]] <- lm(model_formula, data = df)
     }
     return(list(
+      type = "anova",
       models = model_list,
       responses = responses,
       strata = NULL,
@@ -106,6 +107,7 @@ prepare_stratified_models <- function(df, responses, strat_var, factor1, factor2
   }
   
   list(
+    type = "anova",
     models = model_list,
     responses = responses,
     strata = list(var = strat_var, levels = strata),

--- a/R/animal_trial_analyzer/module_visualize.R
+++ b/R/animal_trial_analyzer/module_visualize.R
@@ -58,6 +58,27 @@ visualize_server <- function(id, filtered_data, model_fit) {
     model_info <- reactive({
       model_fit()
     })
+
+    active_analysis_type <- reactiveVal(NULL)
+
+    observe({
+      info <- model_info()
+      if (is.null(info)) return()
+
+      current_type <- if (!is.null(info$type)) info$type else "anova"
+      if (!identical(active_analysis_type(), current_type)) {
+        active_analysis_type(current_type)
+
+        defaults <- if (identical(current_type, "ggpairs")) {
+          list(width = 800, height = 600)
+        } else {
+          list(width = 300, height = 200)
+        }
+
+        updateNumericInput(session, "subplot_width", value = defaults$width)
+        updateNumericInput(session, "subplot_height", value = defaults$height)
+      }
+    })
     
     compute_layout <- function(n_items, rows_input, cols_input) {
       # Safely handle nulls
@@ -150,8 +171,18 @@ visualize_server <- function(id, filtered_data, model_fit) {
     
     output$layout_controls <- renderUI({
       info <- model_info()
-      has_strata <- !is.null(info) && !is.null(info$strata) && !is.null(info$strata$var)
-      n_responses <- if (!is.null(info) && !is.null(info$responses)) length(info$responses) else 0
+      if (is.null(info)) return(NULL)
+
+      current_type <- if (!is.null(info$type)) info$type else "anova"
+      if (identical(current_type, "ggpairs")) {
+        return(tagList(
+          h4("Correlation Plot Options"),
+          helpText("Pairwise correlation plots do not support grid layout controls. Adjust the plot size inputs below to resize the matrix.")
+        ))
+      }
+
+      has_strata <- !is.null(info$strata) && !is.null(info$strata$var)
+      n_responses <- if (!is.null(info$responses)) length(info$responses) else 0
       
       strata_inputs <- if (has_strata) {
         tagList(


### PR DESCRIPTION
## Summary
- tag each analysis module with its analysis type so downstream modules can react to the selected workflow
- add dynamic handling in the visualization module to reset plot size defaults to 300x200 for ANOVA outputs and 800x600 for pairwise correlation matrices
- hide grid layout controls when displaying pairwise correlations while keeping the plot size inputs active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3f0f362a8832b890ee788a609e8c7